### PR TITLE
Fix data race which can occur when using script and derived expression features with concurrent segment search

### DIFF
--- a/src/javaRestTest/java/com/o19s/es/ltr/action/BaseIntegrationTest.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/action/BaseIntegrationTest.java
@@ -176,9 +176,9 @@ public abstract class BaseIntegrationTest extends OpenSearchSingleNodeTestCase {
                                         public double execute(ExplanationHolder explainationHolder) {
                                             // For testing purposes just look for the "terms" key and see if stats were injected
                                             if(p.containsKey("termStats")) {
-                                                AbstractMap<String, ArrayList<Float>> termStats = (AbstractMap<String,
-                                                        ArrayList<Float>>) p.get("termStats");
-                                                ArrayList<Float> dfStats = termStats.get("df");
+                                                Supplier<AbstractMap<String, ArrayList<Float>>> termStats = (Supplier<AbstractMap<String,
+                                                        ArrayList<Float>>>) p.get("termStats");
+                                                ArrayList<Float> dfStats = termStats.get().get("df");
                                                 return dfStats.size() > 0 ? dfStats.get(0) : 0.0;
                                             } else {
                                                 return 0.0;

--- a/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/logging/LoggingIT.java
@@ -31,7 +31,6 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.opensearch.common.lucene.search.function.FunctionScoreQuery;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.InnerHitBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;

--- a/src/main/java/com/o19s/es/ltr/utils/Suppliers.java
+++ b/src/main/java/com/o19s/es/ltr/utils/Suppliers.java
@@ -17,7 +17,6 @@
 package com.o19s.es.ltr.utils;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 public final class Suppliers {
@@ -57,22 +56,6 @@ public final class Suppliers {
                 }
             }
             return value;
-        }
-    }
-
-    /**
-     * A mutable supplier
-     */
-    public static class MutableSupplier<T> implements Supplier<T> {
-        private final AtomicReference<T> ref = new AtomicReference<>();
-
-        @Override
-        public T get() {
-            return ref.get();
-        }
-
-        public void set(T obj) {
-            this.ref.set(obj);
         }
     }
 }

--- a/src/main/java/com/o19s/es/termstat/TermStatSupplier.java
+++ b/src/main/java/com/o19s/es/termstat/TermStatSupplier.java
@@ -17,7 +17,6 @@ package com.o19s.es.termstat;
 
 import com.o19s.es.explore.StatisticsHelper;
 import com.o19s.es.explore.StatisticsHelper.AggrType;
-import com.o19s.es.ltr.utils.Suppliers;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.ReaderUtil;
@@ -48,12 +47,10 @@ public class TermStatSupplier extends AbstractMap<String, ArrayList<Float>>  {
 
     private final ClassicSimilarity sim;
     private final StatisticsHelper df_stats, idf_stats, tf_stats, ttf_stats, tp_stats;
-    private final Suppliers.MutableSupplier<Integer> matchedCountSupplier;
 
     private int matchedTermCount = 0;
 
     public TermStatSupplier() {
-        this.matchedCountSupplier = new Suppliers.MutableSupplier<>();
         this.sim = new ClassicSimilarity();
         this.df_stats = new StatisticsHelper();
         this.idf_stats = new StatisticsHelper();
@@ -124,8 +121,6 @@ public class TermStatSupplier extends AbstractMap<String, ArrayList<Float>>  {
                 tp_stats.add(0.0f);
             }
         }
-
-        matchedCountSupplier.set(matchedTermCount);
     }
 
     /**
@@ -227,10 +222,6 @@ public class TermStatSupplier extends AbstractMap<String, ArrayList<Float>>  {
 
     public int getMatchedTermCount() {
         return matchedTermCount;
-    }
-
-    public Suppliers.MutableSupplier<Integer> getMatchedTermCountSupplier() {
-        return matchedCountSupplier;
     }
 
     public void setPosAggr(AggrType type) {

--- a/src/test/java/com/o19s/es/ltr/feature/store/FeatureSupplierTests.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/FeatureSupplierTests.java
@@ -19,7 +19,6 @@ package com.o19s.es.ltr.feature.store;
 import com.o19s.es.ltr.feature.FeatureSet;
 import com.o19s.es.ltr.ranker.DenseFeatureVector;
 import com.o19s.es.ltr.ranker.LtrRanker;
-import com.o19s.es.ltr.utils.Suppliers;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.opensearch.index.query.QueryBuilders;
 
@@ -45,10 +44,8 @@ public class FeatureSupplierTests extends LuceneTestCase {
 
     public void testGetWhenFeatureVectorSet() {
         FeatureSupplier featureSupplier = new FeatureSupplier(getFeatureSet());
-        Suppliers.MutableSupplier<LtrRanker.FeatureVector> vectorSupplier = new Suppliers.MutableSupplier<>();
         LtrRanker.FeatureVector featureVector = new DenseFeatureVector(1);
-        vectorSupplier.set(featureVector);
-        featureSupplier.set(vectorSupplier);
+        featureSupplier.set(() -> featureVector);
         assertEquals(featureVector, featureSupplier.get());
     }
 
@@ -60,11 +57,9 @@ public class FeatureSupplierTests extends LuceneTestCase {
 
     public void testGetFeatureScore() {
         FeatureSupplier featureSupplier = new FeatureSupplier(getFeatureSet());
-        Suppliers.MutableSupplier<LtrRanker.FeatureVector> vectorSupplier = new Suppliers.MutableSupplier<>();
         LtrRanker.FeatureVector featureVector = new DenseFeatureVector(1);
         featureVector.setFeatureScore(0, 10.0f);
-        vectorSupplier.set(featureVector);
-        featureSupplier.set(vectorSupplier);
+        featureSupplier.set(() -> featureVector);
         assertEquals(10.0f, featureSupplier.get("test"), 0.0f);
         assertNull(featureSupplier.get("bad_test"));
     }
@@ -81,11 +76,9 @@ public class FeatureSupplierTests extends LuceneTestCase {
 
     public void testEntrySetWhenFeatureVectorIsSet(){
         FeatureSupplier featureSupplier = new FeatureSupplier(getFeatureSet());
-        Suppliers.MutableSupplier<LtrRanker.FeatureVector> vectorSupplier = new Suppliers.MutableSupplier<>();
         LtrRanker.FeatureVector featureVector = new DenseFeatureVector(1);
         featureVector.setFeatureScore(0, 10.0f);
-        vectorSupplier.set(featureVector);
-        featureSupplier.set(vectorSupplier);
+        featureSupplier.set(() -> featureVector);
 
         Set<Map.Entry<String, Float>> entrySet = featureSupplier.entrySet();
         assertFalse(entrySet.isEmpty());


### PR DESCRIPTION
### Description

A candidate fix as discussed in https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/52. It is implemented using thread locals to share state between nested data structures in order to share common statistics such as the terms stats and feature vector

### Issues Resolved
Fixes: https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/52

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
