### PR TITLE
fix: fixed namings of test classes

### DIFF
--- a/src/test/java/org/opensearch/ltr/breaker/LTRCircuitBreakerServiceTests.java
+++ b/src/test/java/org/opensearch/ltr/breaker/LTRCircuitBreakerServiceTests.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.when;
 
-public class LTRCircuitBreakerServiceTest {
+public class LTRCircuitBreakerServiceTests {
 
     @InjectMocks
     private LTRCircuitBreakerService ltrCircuitBreakerService;

--- a/src/test/java/org/opensearch/ltr/breaker/MemoryCircuitBreakerTests.java
+++ b/src/test/java/org/opensearch/ltr/breaker/MemoryCircuitBreakerTests.java
@@ -26,7 +26,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
 
-public class MemoryCircuitBreakerTest {
+public class MemoryCircuitBreakerTests {
 
     @Mock
     JvmService jvmService;


### PR DESCRIPTION
Fixed some test class names that did not meet the expected naming pattern (*Test instead of *Tests)