### PR TITLE
Adding Yaliang Wu, Jing Zhang, and Rithin Pullela as maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gsingers @macohen @sstults @JohannesDaniel
+* @gsingers @macohen @sstults @JohannesDaniel @ylwu-amzn @jngz-es @rithin-pullela-aws

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,7 +14,9 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Grant Ingersoll | [gsingers](https://github.com/gsingers)             | Develomentor           |
 | Scott Stults    | [sstults](https://github.com/sstults)               | OpenSource Connections |
 | Johannes Peter  | [JohannesDaniel](https://github.com/JohannesDaniel) | Principal Engineer     |
-
+| Yaliang Wu      | [ylwu-amzn](https://github.com/ylwu-amzn)           | Amazon                 |
+| Jing Zhang      | [jngz-es](https://github.com/jngz-es)               | Amazon                 |
+| Rithin Pullela  | [rithin-pullela-aws](https://github.com/rithin-pullela-aws) | Amazon                 |
 
 ## Emeritus
 


### PR DESCRIPTION
I have nominated Yaliang Wu, Jing Zhang, and Rithin Pullela as maintainers, and the current maintainers have voted and approved. They have contributed code important to running the plugin in a large service environment and have contributed elsewhere in the OpenSearch project.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
