### PR TITLE
Add a custom task integTest to trigger integration tests.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Build LTR Plugin
+      - name: Build and Run Tests
         run: |
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c 'whoami && java -version && 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import java.nio.file.Files
+import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
   ext {
@@ -172,6 +173,19 @@ validateNebulaPom.enabled = false
 // Elastic tried to remove the logging requirement for plugins, but didn't get it quite right so this is a short term fix until 7.11
 // https://github.com/elastic/opensearch/issues/65247
 loggerUsageCheck.enabled = false
+
+// Custom task for running integration tests
+task integTest(type: RestIntegTestTask) {
+  description = "Run integration tests from src/javaRestTest"
+  // Specify the classpath for integration tests
+  testClassesDirs = sourceSets.javaRestTest.output.classesDirs
+  classpath = sourceSets.javaRestTest.runtimeClasspath
+}
+
+testClusters.integTest {
+  // adds LTR as a plugin to the OS build
+  plugin(project.tasks.bundlePlugin.archiveFile)
+}
 
 tasks.withType(Test).configureEach { task ->
     if (JavaVersion.current().compareTo(JavaVersion.VERSION_17) > 0 && JavaVersion.current().compareTo(JavaVersion.VERSION_21) < 0) {


### PR DESCRIPTION
### Description
Now the integration tests can be triggered by `./gradlew integTest`

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
