### PR TITLE
Added builds against JAVA 11 and 17

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
     needs: [Get-CI-Image-Tag, spotless]
     strategy:
       matrix:
-        java: [21]
+        java: [ 11, 17, 21 ]
 
     name: Build and Test LTR Plugin on Linux
     if: github.repository == 'opensearch-project/opensearch-learning-to-rank-base'


### PR DESCRIPTION
### Description
We only need the JAVA 11 and 17 build support in 2.x branch

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
