### PR TITLE
Modified Rest Handlers to stash context before modifying system indices

### DIFF
--- a/src/test/resources/rest-api-spec/test/fstore/10_manage.yml
+++ b/src/test/resources/rest-api-spec/test/fstore/10_manage.yml
@@ -179,6 +179,8 @@
           index:  test
 
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.ltrstore_custom], but in a future major version, direct access to system indices will be prevented by default"
       search:
         index: test
         body: { query: { "sltr": { "params": {"query_string": "rambo"}, "model": "my_model", "store": "custom" } } }
@@ -191,8 +193,8 @@
   - do:
       allowed_warnings:
         - "this request accesses system indices: [.ltrstore_custom], but in a future major version, direct access to system indices will be prevented by default"
-      indices.delete:
-          index: .ltrstore_custom
+      ltr.delete_store:
+        store: custom
 
   - do:
         ltr.cache_stats: {}
@@ -241,6 +243,8 @@
           index:  test
 
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.ltrstore_custom], but in a future major version, direct access to system indices will be prevented by default"
       search:
         index: test
         body: { query: { "sltr": { "params": {"query_string": "rambo"}, "model": "my_model", "store": "custom" } } }

--- a/src/test/resources/rest-api-spec/test/fstore/70_validation.yml
+++ b/src/test/resources/rest-api-spec/test/fstore/70_validation.yml
@@ -155,9 +155,9 @@
   - skip:
       features: allowed_warnings
   - do:
-        ltr.create_store: {}
         allowed_warnings:
           - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
+        ltr.create_store: {}
   - do:
         indices.create:
           index: test_index

--- a/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
+++ b/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
@@ -138,7 +138,11 @@ setup:
 
 ---
 "single feature ranklib model":
+  - skip:
+      features: allowed_warnings
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
       search:
         index: test
         body: { query: { "sltr": { "params": {"query_string": "rambo"}, "model": "single_feature_ranklib_model"  } } }
@@ -148,7 +152,11 @@ setup:
 
 ---
 "single feature linear model":
+  - skip:
+      features: allowed_warnings
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
       search:
         index: test
         body: { query: { "sltr": { "params": {"query_string": "rambo"}, "model": "single_feature_linear_model"  } } }
@@ -157,7 +165,11 @@ setup:
 
 ---
 "three feature linear model using one active feature":
+  - skip:
+      features: allowed_warnings
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
       search:
         index: test
         body: { query: { "sltr": { "params": {}, "model": "three_feature_linear_model", "active_features": ["no_param_feature"]}  } }


### PR DESCRIPTION
Also modified test cases to handle warnings

### Description

- The indices that start with .`ltrstore` are considered as system indices. And before accessing the system indices, we need to stash the thread context. Added code to perform context stashing before accessing these indices.
- Modified yaml test cases to handle warnings.


### Issues Resolved
#120

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
