### PR TITLE
Stash context for GET calls and Modify ITs to ignore transient warnings

### DIFF
--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -372,7 +372,7 @@ public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, Script
     @Override
     public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
         List<SystemIndexDescriptor> systemIndexDescriptors = new ArrayList<>();
-        systemIndexDescriptors.add(new SystemIndexDescriptor(".ltrstore*", "ML Commons Agent Index"));
+        systemIndexDescriptors.add(new SystemIndexDescriptor(".ltrstore*", "Indices for LTR stores"));
         return systemIndexDescriptors;
     }
 }

--- a/src/test/resources/rest-api-spec/test/fstore/10_manage.yml
+++ b/src/test/resources/rest-api-spec/test/fstore/10_manage.yml
@@ -118,6 +118,7 @@
   - do:
         allowed_warnings:
           - "this request accesses system indices: [.ltrstore_mystore], but in a future major version, direct access to system indices will be prevented by default"
+          - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
         ltr.list_stores: {}
 
   - match: { stores._default_.version: 2 }

--- a/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
+++ b/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
@@ -68,6 +68,8 @@ setup:
 # Model only uses a single feature... although feature set has multiple
 
   - do:
+      allowed_warnings:
+      - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
 
   - do:
@@ -134,6 +136,8 @@ setup:
                     no_param_feature: 3.0
 
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
       indices.refresh: {}
 
 ---


### PR DESCRIPTION
### Description
Stashing context allows get calls to succeed.
The warnings occur flakily.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
