### PR TITLE
[Release 3.0] Bump gradle to 8.10.2 and support JDK23

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,12 +6,7 @@ on:
       - 'backport/**'
       - 'create-pull-request/**'
       - 'dependabot/**'
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-
-permissions:
-  id-token: write
-  contents: read
+  pull_request:
 
 jobs:
   Get-CI-Image-Tag:
@@ -22,16 +17,18 @@ jobs:
   spotless:
     if: github.repository == 'opensearch-project/opensearch-learning-to-rank-base'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [21, 23]
     steps:
       - name: Checkout LTR
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       # Spotless requires JDK 17+
-      - name: Setup Java 21
-        uses: actions/setup-java@v1
+      - name: Setup Java
+        uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
       - name: Spotless Check
         run: ./gradlew spotlessCheck
 
@@ -39,7 +36,7 @@ jobs:
     needs: [Get-CI-Image-Tag, spotless]
     strategy:
       matrix:
-        java: [21]
+        java: [21, 23]
 
     name: Build and Test LTR Plugin on Linux
     if: github.repository == 'opensearch-project/opensearch-learning-to-rank-base'
@@ -63,8 +60,6 @@ jobs:
 
       - name: Checkout LTR Code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Build and Run Tests
         run: |
@@ -76,7 +71,7 @@ jobs:
   Build-ltr-windows:
     strategy:
       matrix:
-        java: [ 21 ]
+        java: [21 , 23]
     name: Build and Test LTR Plugin on Windows
     if: github.repository == 'opensearch-project/opensearch-learning-to-rank-base'
     needs: [spotless]
@@ -89,8 +84,6 @@ jobs:
           distribution: 'temurin'
       - name: Checkout LTR Code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Build and Run Tests
         shell: bash
         run: |

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionSha256Sum=2ab88d6de2c23e6adae7363ae6e29cbdd2a709e992929b48b6530fd0c7133bd6
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Description
[Release 3.0] Bump gradle to 8.10.2 and support JDK23

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/131

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
