### PR TITLE
[Backport to 2.x] Refactor index refresh logic in ITs #135

### DIFF
--- a/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
+++ b/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
@@ -19,6 +19,9 @@ setup:
         body:   { "field1": "v1 aoeu", "field2": " ua u v2", "field3": "foo bar text", "user_rating": 0.0  }
 
   - do:
+      indices.refresh: { test }
+
+  - do:
           allowed_warnings:
             - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
           ltr.create_store: {}
@@ -66,11 +69,6 @@ setup:
                   template:  {"function_score": { "functions": [ {"field_value_factor": { "field": "user_rating" } }], "query": {"match_all": {}}}}
 
 # Model only uses a single feature... although feature set has multiple
-
-  - do:
-      allowed_warnings:
-      - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
-      indices.refresh: {}
 
   - do:
         allowed_warnings:
@@ -134,11 +132,6 @@ setup:
                     feature1: 1.3
                     feature2: 2.3
                     no_param_feature: 3.0
-
-  - do:
-      allowed_warnings:
-        - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
-      indices.refresh: {}
 
 ---
 "single feature ranklib model":


### PR DESCRIPTION
### Description
Instead of refreshing all indices, which could lead to a warning when a system index is refreshed and cause the test to fail due to the unexpected warning, I modified the logic to refresh only the required 'test' index.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
