### PR TITLE
[Backport 2.19] Add a model parser for xgboost (for the correct serialization format) (#151)

### DIFF
--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -115,6 +115,7 @@ import com.o19s.es.ltr.query.ValidatingLtrQueryBuilder;
 import com.o19s.es.ltr.ranker.parser.LinearRankerParser;
 import com.o19s.es.ltr.ranker.parser.LtrRankerParserFactory;
 import com.o19s.es.ltr.ranker.parser.XGBoostJsonParser;
+import com.o19s.es.ltr.ranker.parser.XGBoostRawJsonParser;
 import com.o19s.es.ltr.ranker.ranklib.RankLibScriptEngine;
 import com.o19s.es.ltr.ranker.ranklib.RanklibModelParser;
 import com.o19s.es.ltr.rest.RestAddFeatureToSet;
@@ -144,6 +145,7 @@ public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, Script
             .register(RanklibModelParser.TYPE, () -> new RanklibModelParser(ranklib.get()))
             .register(LinearRankerParser.TYPE, LinearRankerParser::new)
             .register(XGBoostJsonParser.TYPE, XGBoostJsonParser::new)
+            .register(XGBoostRawJsonParser.TYPE, XGBoostRawJsonParser::new)
             .build();
         ltrStats = getInitialStats();
     }

--- a/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
@@ -124,6 +124,22 @@ public class NaiveAdditiveDecisionTree extends DenseLtrRanker implements Account
             return n.eval(scores);
         }
 
+        public Node getLeft() {
+            return this.left;
+        }
+
+        public Node getRight() {
+            return this.right;
+        }
+
+        public int getFeature() {
+            return this.feature;
+        }
+
+        public float getThreshold() {
+            return this.threshold;
+        }
+
         /**
          * Return the memory usage of this object in bytes. Negative values are illegal.
          */

--- a/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParser.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.ranker.parser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Optional;
+
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.ParseField;
+import org.opensearch.core.common.ParsingException;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ObjectParser;
+import org.opensearch.core.xcontent.XContentParseException;
+import org.opensearch.core.xcontent.XContentParser;
+
+import com.o19s.es.ltr.feature.FeatureSet;
+import com.o19s.es.ltr.ranker.dectree.NaiveAdditiveDecisionTree;
+import com.o19s.es.ltr.ranker.normalizer.Normalizer;
+import com.o19s.es.ltr.ranker.normalizer.Normalizers;
+
+public class XGBoostRawJsonParser implements LtrRankerParser {
+
+    public static final String TYPE = "model/xgboost+json+raw";
+
+    @Override
+    public NaiveAdditiveDecisionTree parse(FeatureSet set, String model) {
+        XGBoostRawJsonParser.XGBoostDefinition modelDefinition;
+        try (
+            XContentParser parser = JsonXContent.jsonXContent
+                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, model)
+        ) {
+            modelDefinition = XGBoostRawJsonParser.XGBoostDefinition.parse(parser, set);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Cannot parse model", e);
+        }
+
+        NaiveAdditiveDecisionTree.Node[] trees = modelDefinition.getLearner().getTrees(set);
+        List<String> modelFeatures = modelDefinition.learner.featureNames;
+
+        // remap features according to the order in the feature set
+        Map<Integer, Integer> modelFeaturesReordering = new HashMap<>();
+        for (int i = 0; i < modelFeatures.size(); i++) {
+            modelFeaturesReordering.put(i, set.featureOrdinal(modelFeatures.get(i)));
+        }
+
+        // Reorder features in each tree
+        NaiveAdditiveDecisionTree.Node[] adjustedTrees = new NaiveAdditiveDecisionTree.Node[trees.length];
+        for (int i = 0; i < trees.length; i++) {
+            adjustedTrees[i] = reorderTreeFeatures(trees[i], modelFeaturesReordering);
+        }
+
+        float[] weights = new float[trees.length];
+        Arrays.fill(weights, 1F);
+        return new NaiveAdditiveDecisionTree(
+            adjustedTrees,
+            weights,
+            set.size(),
+            modelDefinition.getLearner().getObjective().getNormalizer()
+        );
+    }
+
+    private NaiveAdditiveDecisionTree.Node reorderTreeFeatures(
+        NaiveAdditiveDecisionTree.Node node,
+        Map<Integer, Integer> modelFeaturesReordering
+    ) {
+        if (node instanceof NaiveAdditiveDecisionTree.Split splitNode) {
+            return new NaiveAdditiveDecisionTree.Split(
+                reorderTreeFeatures(splitNode.getLeft(), modelFeaturesReordering),
+                reorderTreeFeatures(splitNode.getRight(), modelFeaturesReordering),
+                modelFeaturesReordering.get(splitNode.getFeature()),
+                splitNode.getThreshold()
+            );
+        }
+
+        // if the node is Leaf we don't do anything
+        return node;
+    }
+
+    private static class XGBoostDefinition {
+        private static final ObjectParser<XGBoostRawJsonParser.XGBoostDefinition, FeatureSet> PARSER;
+
+        static {
+            PARSER = new ObjectParser<>("xgboost_definition", true, XGBoostRawJsonParser.XGBoostDefinition::new);
+            PARSER
+                .declareObject(
+                    XGBoostRawJsonParser.XGBoostDefinition::setLearner,
+                    XGBoostRawJsonParser.XGBoostLearner::parse,
+                    new ParseField("learner")
+                );
+            PARSER.declareIntArray(XGBoostRawJsonParser.XGBoostDefinition::setVersion, new ParseField("version"));
+        }
+
+        public static XGBoostRawJsonParser.XGBoostDefinition parse(XContentParser parser, FeatureSet set) throws IOException {
+            XGBoostRawJsonParser.XGBoostDefinition definition;
+            XContentParser.Token startToken = parser.nextToken();
+
+            if (startToken == XContentParser.Token.START_OBJECT) {
+                try {
+                    definition = PARSER.apply(parser, set);
+                } catch (XContentParseException e) {
+                    throw new ParsingException(parser.getTokenLocation(), "Unable to parse XGBoost object", e);
+                }
+                if (definition.learner == null) {
+                    throw new ParsingException(parser.getTokenLocation(), "XGBoost model missing required field [learner]");
+                }
+                List<String> unknownFeatures = new ArrayList<>();
+                for (String modelFeatureName : definition.learner.featureNames) {
+                    if (!set.hasFeature(modelFeatureName)) {
+                        unknownFeatures.add(modelFeatureName);
+                    }
+                }
+                if (!unknownFeatures.isEmpty()) {
+                    throw new ParsingException(
+                        parser.getTokenLocation(),
+                        "Unknown features in model: [" + String.join(", ", unknownFeatures) + "]"
+                    );
+                }
+                if (definition.learner.featureNames.size() != definition.learner.featureTypes.size()) {
+                    throw new ParsingException(
+                        parser.getTokenLocation(),
+                        "Feature names list and feature types list must have the same length"
+                    );
+                }
+                Optional<String> firstUnsupportedType = definition.learner.featureTypes
+                    .stream()
+                    .filter(typeStr -> !typeStr.equals("float"))
+                    .findFirst();
+                if (firstUnsupportedType.isPresent()) {
+                    throw new ParsingException(
+                        parser.getTokenLocation(),
+                        "The LTR plugin only supports float feature types "
+                            + "because Elasticsearch scores are always float32. "
+                            + "Found feature type ["
+                            + firstUnsupportedType.get()
+                            + "] in model"
+                    );
+                }
+            } else {
+                throw new ParsingException(parser.getTokenLocation(), "Expected [START_OBJECT] but got [" + startToken + "]");
+            }
+
+            return definition;
+        }
+
+        private XGBoostLearner learner;
+
+        public XGBoostLearner getLearner() {
+            return learner;
+        }
+
+        public void setLearner(XGBoostLearner learner) {
+            this.learner = learner;
+        }
+
+        private List<Integer> version;
+
+        public List<Integer> getVersion() {
+            return version;
+        }
+
+        public void setVersion(List<Integer> version) {
+            this.version = version;
+        }
+    }
+
+    static class XGBoostLearner {
+
+        private List<String> featureNames;
+        private List<String> featureTypes;
+        private XGBoostGradientBooster gradientBooster;
+        private XGBoostObjective objective;
+
+        private static final ObjectParser<XGBoostRawJsonParser.XGBoostLearner, FeatureSet> PARSER;
+
+        static {
+            PARSER = new ObjectParser<>("xgboost_learner", true, XGBoostRawJsonParser.XGBoostLearner::new);
+            PARSER
+                .declareObject(
+                    XGBoostRawJsonParser.XGBoostLearner::setObjective,
+                    XGBoostRawJsonParser.XGBoostObjective::parse,
+                    new ParseField("objective")
+                );
+            PARSER
+                .declareObject(
+                    XGBoostRawJsonParser.XGBoostLearner::setGradientBooster,
+                    XGBoostRawJsonParser.XGBoostGradientBooster::parse,
+                    new ParseField("gradient_booster")
+                );
+            PARSER.declareStringArray(XGBoostRawJsonParser.XGBoostLearner::setFeatureNames, new ParseField("feature_names"));
+            PARSER.declareStringArray(XGBoostRawJsonParser.XGBoostLearner::setFeatureTypes, new ParseField("feature_types"));
+        }
+
+        private void setFeatureTypes(List<String> featureTypes) {
+            this.featureTypes = featureTypes;
+        }
+
+        private void setFeatureNames(List<String> featureNames) {
+            this.featureNames = featureNames;
+        }
+
+        public static XGBoostRawJsonParser.XGBoostLearner parse(XContentParser parser, FeatureSet set) throws IOException {
+            return PARSER.apply(parser, set);
+        }
+
+        XGBoostLearner() {}
+
+        NaiveAdditiveDecisionTree.Node[] getTrees(FeatureSet set) {
+            return this.getGradientBooster().getModel().getTrees();
+        }
+
+        public XGBoostObjective getObjective() {
+            return objective;
+        }
+
+        public void setObjective(XGBoostObjective objective) {
+            this.objective = objective;
+        }
+
+        public XGBoostGradientBooster getGradientBooster() {
+            return gradientBooster;
+        }
+
+        public void setGradientBooster(XGBoostGradientBooster gradientBooster) {
+            this.gradientBooster = gradientBooster;
+        }
+    }
+
+    static class XGBoostGradientBooster {
+        private XGBoostModel model;
+
+        private static final ObjectParser<XGBoostRawJsonParser.XGBoostGradientBooster, FeatureSet> PARSER;
+
+        static {
+            PARSER = new ObjectParser<>("xgboost_gradient_booster", true, XGBoostRawJsonParser.XGBoostGradientBooster::new);
+            PARSER
+                .declareObject(
+                    XGBoostRawJsonParser.XGBoostGradientBooster::setModel,
+                    XGBoostRawJsonParser.XGBoostModel::parse,
+                    new ParseField("model")
+                );
+        }
+
+        static XGBoostRawJsonParser.XGBoostGradientBooster parse(XContentParser parser, FeatureSet set) throws IOException {
+            return PARSER.apply(parser, set);
+        }
+
+        XGBoostGradientBooster() {}
+
+        public XGBoostModel getModel() {
+            return model;
+        }
+
+        public void setModel(XGBoostModel model) {
+            this.model = model;
+        }
+    }
+
+    static class XGBoostModel {
+        private NaiveAdditiveDecisionTree.Node[] trees;
+        private List<Integer> treeInfo;
+
+        private static final ObjectParser<XGBoostRawJsonParser.XGBoostModel, FeatureSet> PARSER;
+
+        static {
+            PARSER = new ObjectParser<>("xgboost_model", true, XGBoostRawJsonParser.XGBoostModel::new);
+            PARSER
+                .declareObjectArray(
+                    XGBoostRawJsonParser.XGBoostModel::setTrees,
+                    XGBoostRawJsonParser.XGBoostTree::parse,
+                    new ParseField("trees")
+                );
+            PARSER.declareIntArray(XGBoostRawJsonParser.XGBoostModel::setTreeInfo, new ParseField("tree_info"));
+        }
+
+        public List<Integer> getTreeInfo() {
+            return treeInfo;
+        }
+
+        public void setTreeInfo(List<Integer> treeInfo) {
+            this.treeInfo = treeInfo;
+        }
+
+        public static XGBoostRawJsonParser.XGBoostModel parse(XContentParser parser, FeatureSet set) throws IOException {
+            try {
+                return PARSER.apply(parser, set);
+            } catch (IllegalArgumentException e) {
+                throw new ParsingException(parser.getTokenLocation(), e.getMessage(), e);
+            }
+        }
+
+        XGBoostModel() {}
+
+        public NaiveAdditiveDecisionTree.Node[] getTrees() {
+            return trees;
+        }
+
+        public void setTrees(List<XGBoostTree> parsedTrees) {
+            NaiveAdditiveDecisionTree.Node[] trees = new NaiveAdditiveDecisionTree.Node[parsedTrees.size()];
+            ListIterator<XGBoostRawJsonParser.XGBoostTree> it = parsedTrees.listIterator();
+            while (it.hasNext()) {
+                trees[it.nextIndex()] = it.next().getRootNode();
+            }
+            this.trees = trees;
+        }
+    }
+
+    static class XGBoostObjective {
+        private Normalizer normalizer;
+
+        private static final ObjectParser<XGBoostRawJsonParser.XGBoostObjective, FeatureSet> PARSER;
+
+        static {
+            PARSER = new ObjectParser<>("xgboost_objective", true, XGBoostRawJsonParser.XGBoostObjective::new);
+            PARSER.declareString(XGBoostRawJsonParser.XGBoostObjective::setName, new ParseField("name"));
+        }
+
+        public static XGBoostRawJsonParser.XGBoostObjective parse(XContentParser parser, FeatureSet set) throws IOException {
+            return PARSER.apply(parser, set);
+        }
+
+        XGBoostObjective() {}
+
+        public void setName(String name) {
+            switch (name) {
+                case "binary:logitraw", "rank:ndcg", "rank:map", "rank:pairwise", "reg:linear" -> this.normalizer = Normalizers
+                    .get(Normalizers.NOOP_NORMALIZER_NAME);
+                case "binary:logistic", "reg:logistic" -> this.normalizer = Normalizers.get(Normalizers.SIGMOID_NORMALIZER_NAME);
+                default -> throw new IllegalArgumentException("Objective [" + name + "] is not a valid XGBoost objective");
+            }
+        }
+
+        Normalizer getNormalizer() {
+            return this.normalizer;
+        }
+    }
+
+    static class XGBoostTree {
+        private Integer treeId;
+        private List<Integer> leftChildren;
+        private List<Integer> rightChildren;
+        private List<Integer> parents;
+        private List<Float> splitConditions;
+        private List<Integer> splitIndices;
+        private List<Integer> defaultLeft;
+        private List<Integer> splitTypes;
+        private List<Float> baseWeights;
+
+        private NaiveAdditiveDecisionTree.Node rootNode;
+
+        private static final ObjectParser<XGBoostRawJsonParser.XGBoostTree, FeatureSet> PARSER;
+
+        static {
+            PARSER = new ObjectParser<>("xgboost_tree", true, XGBoostRawJsonParser.XGBoostTree::new);
+            PARSER.declareInt(XGBoostRawJsonParser.XGBoostTree::setTreeId, new ParseField("id"));
+            PARSER.declareIntArray(XGBoostRawJsonParser.XGBoostTree::setLeftChildren, new ParseField("left_children"));
+            PARSER.declareIntArray(XGBoostRawJsonParser.XGBoostTree::setRightChildren, new ParseField("right_children"));
+            PARSER.declareIntArray(XGBoostRawJsonParser.XGBoostTree::setParents, new ParseField("parents"));
+            PARSER.declareFloatArray(XGBoostRawJsonParser.XGBoostTree::setSplitConditions, new ParseField("split_conditions"));
+            PARSER.declareIntArray(XGBoostRawJsonParser.XGBoostTree::setSplitIndices, new ParseField("split_indices"));
+            PARSER.declareIntArray(XGBoostRawJsonParser.XGBoostTree::setDefaultLeft, new ParseField("default_left"));
+            PARSER.declareIntArray(XGBoostRawJsonParser.XGBoostTree::setSplitTypes, new ParseField("split_type"));
+            PARSER.declareFloatArray(XGBoostRawJsonParser.XGBoostTree::setBaseWeights, new ParseField("base_weights"));
+        }
+
+        public static XGBoostRawJsonParser.XGBoostTree parse(XContentParser parser, FeatureSet set) throws IOException {
+            XGBoostRawJsonParser.XGBoostTree tree = PARSER.apply(parser, set);
+            tree.rootNode = tree.asLibTree(0);
+            return tree;
+        }
+
+        public Integer getTreeId() {
+            return treeId;
+        }
+
+        public void setTreeId(Integer treeId) {
+            this.treeId = treeId;
+        }
+
+        public List<Integer> getLeftChildren() {
+            return leftChildren;
+        }
+
+        public void setLeftChildren(List<Integer> leftChildren) {
+            this.leftChildren = leftChildren;
+        }
+
+        public List<Integer> getRightChildren() {
+            return rightChildren;
+        }
+
+        public void setRightChildren(List<Integer> rightChildren) {
+            this.rightChildren = rightChildren;
+        }
+
+        public List<Integer> getParents() {
+            return parents;
+        }
+
+        public void setParents(List<Integer> parents) {
+            this.parents = parents;
+        }
+
+        public List<Float> getSplitConditions() {
+            return splitConditions;
+        }
+
+        public void setSplitConditions(List<Float> splitConditions) {
+            this.splitConditions = splitConditions;
+        }
+
+        public List<Integer> getSplitIndices() {
+            return splitIndices;
+        }
+
+        public void setSplitIndices(List<Integer> splitIndices) {
+            this.splitIndices = splitIndices;
+        }
+
+        public List<Integer> getDefaultLeft() {
+            return defaultLeft;
+        }
+
+        public void setDefaultLeft(List<Integer> defaultLeft) {
+            this.defaultLeft = defaultLeft;
+        }
+
+        public List<Integer> getSplitTypes() {
+            return splitTypes;
+        }
+
+        public void setSplitTypes(List<Integer> splitTypes) {
+            this.splitTypes = splitTypes;
+        }
+
+        private boolean isSplit(Integer nodeId) {
+            return leftChildren.get(nodeId) != -1 && rightChildren.get(nodeId) != -1;
+        }
+
+        private NaiveAdditiveDecisionTree.Node asLibTree(Integer nodeId) {
+            if (nodeId >= leftChildren.size()) {
+                throw new IllegalArgumentException("Child node reference ID [" + nodeId + "] is invalid");
+            }
+            if (nodeId >= rightChildren.size()) {
+                throw new IllegalArgumentException("Child node reference ID [" + nodeId + "] is invalid");
+            }
+
+            if (isSplit(nodeId)) {
+                return new NaiveAdditiveDecisionTree.Split(
+                    asLibTree(leftChildren.get(nodeId)),
+                    asLibTree(rightChildren.get(nodeId)),
+                    splitIndices.get(nodeId),
+                    splitConditions.get(nodeId)
+                );
+            } else {
+                return new NaiveAdditiveDecisionTree.Leaf(baseWeights.get(nodeId));
+            }
+        }
+
+        public List<Float> getBaseWeights() {
+            return baseWeights;
+        }
+
+        public void setBaseWeights(List<Float> baseWeights) {
+            this.baseWeights = baseWeights;
+        }
+
+        public NaiveAdditiveDecisionTree.Node getRootNode() {
+            return rootNode;
+        }
+    }
+}

--- a/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParser.java
@@ -84,7 +84,8 @@ public class XGBoostRawJsonParser implements LtrRankerParser {
         NaiveAdditiveDecisionTree.Node node,
         Map<Integer, Integer> modelFeaturesReordering
     ) {
-        if (node instanceof NaiveAdditiveDecisionTree.Split splitNode) {
+        if (node instanceof NaiveAdditiveDecisionTree.Split) {
+            NaiveAdditiveDecisionTree.Split splitNode = (NaiveAdditiveDecisionTree.Split) node;
             return new NaiveAdditiveDecisionTree.Split(
                 reorderTreeFeatures(splitNode.getLeft(), modelFeaturesReordering),
                 reorderTreeFeatures(splitNode.getRight(), modelFeaturesReordering),
@@ -343,10 +344,19 @@ public class XGBoostRawJsonParser implements LtrRankerParser {
 
         public void setName(String name) {
             switch (name) {
-                case "binary:logitraw", "rank:ndcg", "rank:map", "rank:pairwise", "reg:linear" -> this.normalizer = Normalizers
-                    .get(Normalizers.NOOP_NORMALIZER_NAME);
-                case "binary:logistic", "reg:logistic" -> this.normalizer = Normalizers.get(Normalizers.SIGMOID_NORMALIZER_NAME);
-                default -> throw new IllegalArgumentException("Objective [" + name + "] is not a valid XGBoost objective");
+                case "binary:logitraw":
+                case "rank:ndcg":
+                case "rank:map":
+                case "rank:pairwise":
+                case "reg:linear":
+                    this.normalizer = Normalizers.get(Normalizers.NOOP_NORMALIZER_NAME);
+                    break;
+                case "binary:logistic":
+                case "reg:logistic":
+                    this.normalizer = Normalizers.get(Normalizers.SIGMOID_NORMALIZER_NAME);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Objective [" + name + "] is not a valid XGBoost objective");
             }
         }
 

--- a/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParserTests.java
@@ -1,0 +1,753 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.ranker.parser;
+
+import static com.o19s.es.ltr.LtrTestUtils.randomFeature;
+import static java.util.Collections.singletonList;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.hamcrest.CoreMatchers;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.opensearch.core.common.ParsingException;
+
+import com.o19s.es.ltr.feature.FeatureSet;
+import com.o19s.es.ltr.feature.store.StoredFeatureSet;
+import com.o19s.es.ltr.ranker.LtrRanker.FeatureVector;
+import com.o19s.es.ltr.ranker.dectree.NaiveAdditiveDecisionTree;
+
+public class XGBoostRawJsonParserTests extends LuceneTestCase {
+    private final XGBoostRawJsonParser parser = new XGBoostRawJsonParser();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    public void testSimpleSplit() throws IOException {
+        String model = "{"
+            + "    \"learner\":{"
+            + "        \"attributes\":{},"
+            + "        \"feature_names\":[\"feat1\"],"
+            + "        \"feature_types\":[\"float\"],"
+            + "        \"gradient_booster\":{"
+            + "        \"model\":{"
+            + "            \"gbtree_model_param\":{"
+            + "            \"num_parallel_tree\":\"1\","
+            + "            \"num_trees\":\"1\"},"
+            + "            \"iteration_indptr\":[0,1],"
+            + "            \"tree_info\":[0],"
+            + "            \"trees\":[{"
+            + "                \"base_weights\":[1E0, 10E0, 0E0],"
+            + "                \"categories\":[],"
+            + "                \"categories_nodes\":[],"
+            + "                \"categories_segments\":[],"
+            + "                \"categories_sizes\":[],"
+            + "                \"default_left\":[0, 0, 0],"
+            + "                \"id\":0,"
+            + "                \"left_children\":[2, -1, -1],"
+            + "                \"loss_changes\":[0E0, 0E0, 0E0],"
+            + "                \"parents\":[2147483647, 0, 0],"
+            + "                \"right_children\":[1, -1, -1],"
+            + "                \"split_conditions\":[3E0, -1E0, -1E0],"
+            + "                \"split_indices\":[0, 0, 0],"
+            + "                \"split_type\":[0, 0, 0],"
+            + "                \"sum_hessian\":[1E0, 1E0, 1E0],"
+            + "                \"tree_param\":{"
+            + "                    \"num_deleted\":\"0\","
+            + "                    \"num_feature\":\"1\","
+            + "                    \"num_nodes\":\"3\","
+            + "                    \"size_leaf_vector\":\"1\"}"
+            + "                }"
+            + "            ]},"
+            + "            \"name\":\"gbtree\""
+            + "        },"
+            + "        \"learner_model_param\":{"
+            + "            \"base_score\":\"5E-1\","
+            + "            \"boost_from_average\":\"1\","
+            + "            \"num_class\":\"0\","
+            + "            \"num_feature\":\"1\","
+            + "            \"num_target\":\"1\""
+            + "        },"
+            + "        \"objective\":{"
+            + "            \"name\":\"reg:linear\","
+            + "            \"reg_loss_param\":{\"scale_pos_weight\":\"1\"}"
+            + "        }"
+            + "    },"
+            + "    \"version\":[2,1,0]"
+            + "}";
+
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        FeatureVector featureVector = tree.newFeatureVector(null);
+        featureVector.setFeatureScore(0, 2);
+        assertEquals(0.0, tree.score(featureVector), Math.ulp(0.1F));
+
+        featureVector.setFeatureScore(0, 4);
+        assertEquals(10.0, tree.score(featureVector), Math.ulp(0.1F));
+    }
+
+    public void testReadWithLogisticObjective() throws IOException {
+        String model = "{"
+            + "    \"learner\":{"
+            + "        \"attributes\":{},"
+            + "        \"feature_names\":[\"feat1\"],"
+            + "        \"feature_types\":[\"float\"],"
+            + "        \"gradient_booster\":{"
+            + "        \"model\":{"
+            + "            \"gbtree_model_param\":{"
+            + "            \"num_parallel_tree\":\"1\","
+            + "            \"num_trees\":\"1\"},"
+            + "            \"iteration_indptr\":[0,1],"
+            + "            \"tree_info\":[0],"
+            + "            \"trees\":[{"
+            + "                \"base_weights\":[1E0, -2E-1, 5E-1],"
+            + "                \"categories\":[],"
+            + "                \"categories_nodes\":[],"
+            + "                \"categories_segments\":[],"
+            + "                \"categories_sizes\":[],"
+            + "                \"default_left\":[0, 0, 0],"
+            + "                \"id\":0,"
+            + "                \"left_children\":[2, -1, -1],"
+            + "                \"loss_changes\":[0E0, 0E0, 0E0],"
+            + "                \"parents\":[2147483647, 0, 0],"
+            + "                \"right_children\":[1, -1, -1],"
+            + "                \"split_conditions\":[3E0, -1E0, -1E0],"
+            + "                \"split_indices\":[0, 0, 0],"
+            + "                \"split_type\":[0, 0, 0],"
+            + "                \"sum_hessian\":[1E0, 1E0, 1E0],"
+            + "                \"tree_param\":{"
+            + "                    \"num_deleted\":\"0\","
+            + "                    \"num_feature\":\"1\","
+            + "                    \"num_nodes\":\"3\","
+            + "                    \"size_leaf_vector\":\"1\"}"
+            + "                }"
+            + "            ]},"
+            + "            \"name\":\"gbtree\""
+            + "        },"
+            + "        \"learner_model_param\":{"
+            + "            \"base_score\":\"5E-1\","
+            + "            \"boost_from_average\":\"1\","
+            + "            \"num_class\":\"0\","
+            + "            \"num_feature\":\"1\","
+            + "            \"num_target\":\"1\""
+            + "        },"
+            + "        \"objective\":{"
+            + "            \"name\":\"reg:logistic\","
+            + "            \"reg_loss_param\":{\"scale_pos_weight\":\"1\"}"
+            + "        }"
+            + "    },"
+            + "    \"version\":[2,1,0]"
+            + "}";
+
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        FeatureVector v = tree.newFeatureVector(null);
+        v.setFeatureScore(0, 2);
+        assertEquals(0.62245935F, tree.score(v), Math.ulp(0.62245935F));
+        v.setFeatureScore(0, 4);
+        assertEquals(0.45016602F, tree.score(v), Math.ulp(0.45016602F));
+    }
+
+    public void testBadObjectiveParam() throws IOException {
+        String model = "{"
+            + "    \"learner\":{"
+            + "        \"attributes\":{},"
+            + "        \"feature_names\":[\"feat1\", \"feat2\"],"
+            + "        \"feature_types\":[\"float\", \"float\"],"
+            + "        \"gradient_booster\":{"
+            + "        \"model\":{"
+            + "            \"gbtree_model_param\":{"
+            + "            \"num_parallel_tree\":\"1\","
+            + "            \"num_trees\":\"1\"},"
+            + "            \"iteration_indptr\":[0,1],"
+            + "            \"tree_info\":[0],"
+            + "            \"trees\":[{"
+            + "                \"base_weights\":[1E0, 10E0, 0E0],"
+            + "                \"categories\":[],"
+            + "                \"categories_nodes\":[],"
+            + "                \"categories_segments\":[],"
+            + "                \"categories_sizes\":[],"
+            + "                \"default_left\":[0, 0, 0],"
+            + "                \"id\":0,"
+            + "                \"left_children\":[2, -1, -1],"
+            + "                \"loss_changes\":[0E0, 0E0, 0E0],"
+            + "                \"parents\":[2147483647, 0, 0],"
+            + "                \"right_children\":[1, -1, -1],"
+            + "                \"split_conditions\":[3E0, -1E0, -1E0],"
+            + "                \"split_indices\":[0, 0, 0],"
+            + "                \"split_type\":[0, 0, 0],"
+            + "                \"sum_hessian\":[1E0, 1E0, 1E0],"
+            + "                \"tree_param\":{"
+            + "                    \"num_deleted\":\"0\","
+            + "                    \"num_feature\":\"2\","
+            + "                    \"num_nodes\":\"3\","
+            + "                    \"size_leaf_vector\":\"1\"}"
+            + "                }"
+            + "            ]},"
+            + "            \"name\":\"gbtree\""
+            + "        },"
+            + "        \"learner_model_param\":{"
+            + "            \"base_score\":\"5E-1\","
+            + "            \"boost_from_average\":\"1\","
+            + "            \"num_class\":\"0\","
+            + "            \"num_feature\":\"2\","
+            + "            \"num_target\":\"1\""
+            + "        },"
+            + "        \"objective\":{"
+            + "            \"name\":\"reg:invalid\","
+            + "            \"reg_loss_param\":{\"scale_pos_weight\":\"1\"}"
+            + "        }"
+            + "    },"
+            + "    \"version\":[2,1,0]"
+            + "}";
+
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+        assertThat(
+            expectThrows(ParsingException.class, () -> parser.parse(set, model)).getMessage(),
+            CoreMatchers.containsString("Unable to parse XGBoost object")
+        );
+    }
+
+    public void testBadFeatureTypeParam() throws IOException {
+        String model = "{"
+            + "    \"learner\":{"
+            + "        \"attributes\":{},"
+            + "        \"feature_names\":[\"feat1\"],"
+            + "        \"feature_types\":[\"int\"],"
+            + "        \"gradient_booster\":{"
+            + "        \"model\":{"
+            + "            \"gbtree_model_param\":{"
+            + "            \"num_parallel_tree\":\"1\","
+            + "            \"num_trees\":\"1\"},"
+            + "            \"iteration_indptr\":[0,1],"
+            + "            \"tree_info\":[0],"
+            + "            \"trees\":[{"
+            + "                \"base_weights\":[1E0, 10E0, 0E0],"
+            + "                \"categories\":[],"
+            + "                \"categories_nodes\":[],"
+            + "                \"categories_segments\":[],"
+            + "                \"categories_sizes\":[],"
+            + "                \"default_left\":[0, 0, 0],"
+            + "                \"id\":0,"
+            + "                \"left_children\":[2, -1, -1],"
+            + "                \"loss_changes\":[0E0, 0E0, 0E0],"
+            + "                \"parents\":[2147483647, 0, 0],"
+            + "                \"right_children\":[1, -1, -1],"
+            + "                \"split_conditions\":[3E0, -1E0, -1E0],"
+            + "                \"split_indices\":[0, 0, 0],"
+            + "                \"split_type\":[0, 0, 0],"
+            + "                \"sum_hessian\":[1E0, 1E0, 1E0],"
+            + "                \"tree_param\":{"
+            + "                    \"num_deleted\":\"0\","
+            + "                    \"num_feature\":\"1\","
+            + "                    \"num_nodes\":\"3\","
+            + "                    \"size_leaf_vector\":\"1\"}"
+            + "                }"
+            + "            ]},"
+            + "            \"name\":\"gbtree\""
+            + "        },"
+            + "        \"learner_model_param\":{"
+            + "            \"base_score\":\"5E-1\","
+            + "            \"boost_from_average\":\"1\","
+            + "            \"num_class\":\"0\","
+            + "            \"num_feature\":\"1\","
+            + "            \"num_target\":\"1\""
+            + "        },"
+            + "        \"objective\":{"
+            + "            \"name\":\"reg:linear\","
+            + "            \"reg_loss_param\":{\"scale_pos_weight\":\"1\"}"
+            + "        }"
+            + "    },"
+            + "    \"version\":[2,1,0]"
+            + "}";
+
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+        assertThat(
+            expectThrows(ParsingException.class, () -> parser.parse(set, model)).getMessage(),
+            CoreMatchers
+                .containsString(
+                    "The LTR plugin only supports float feature types because "
+                        + "Elasticsearch scores are always float32. Found feature type [int] in model"
+                )
+        );
+    }
+
+    public void testMismatchingFeatureList() throws IOException {
+        String model = "{"
+            + "    \"learner\":{"
+            + "        \"attributes\":{},"
+            + "        \"feature_names\":[\"feat1\", \"feat2\"],"
+            + "        \"feature_types\":[\"float\"],"
+            + "        \"gradient_booster\":{"
+            + "        \"model\":{"
+            + "            \"gbtree_model_param\":{"
+            + "            \"num_parallel_tree\":\"1\","
+            + "            \"num_trees\":\"1\"},"
+            + "            \"iteration_indptr\":[0,1],"
+            + "            \"tree_info\":[0],"
+            + "            \"trees\":[{"
+            + "                \"base_weights\":[1E0, 10E0, 0E0],"
+            + "                \"categories\":[],"
+            + "                \"categories_nodes\":[],"
+            + "                \"categories_segments\":[],"
+            + "                \"categories_sizes\":[],"
+            + "                \"default_left\":[0, 0, 0],"
+            + "                \"id\":0,"
+            + "                \"left_children\":[2, -1, -1],"
+            + "                \"loss_changes\":[0E0, 0E0, 0E0],"
+            + "                \"parents\":[2147483647, 0, 0],"
+            + "                \"right_children\":[1, -1, -1],"
+            + "                \"split_conditions\":[3E0, -1E0, -1E0],"
+            + "                \"split_indices\":[0, 0, 0],"
+            + "                \"split_type\":[0, 0, 0],"
+            + "                \"sum_hessian\":[1E0, 1E0, 1E0],"
+            + "                \"tree_param\":{"
+            + "                    \"num_deleted\":\"0\","
+            + "                    \"num_feature\":\"2\","
+            + "                    \"num_nodes\":\"3\","
+            + "                    \"size_leaf_vector\":\"1\"}"
+            + "                }"
+            + "            ]},"
+            + "            \"name\":\"gbtree\""
+            + "        },"
+            + "        \"learner_model_param\":{"
+            + "            \"base_score\":\"5E-1\","
+            + "            \"boost_from_average\":\"1\","
+            + "            \"num_class\":\"0\","
+            + "            \"num_feature\":\"2\","
+            + "            \"num_target\":\"1\""
+            + "        },"
+            + "        \"objective\":{"
+            + "            \"name\":\"reg:logistic\","
+            + "            \"reg_loss_param\":{\"scale_pos_weight\":\"1\"}"
+            + "        }"
+            + "    },"
+            + "    \"version\":[2,1,0]"
+            + "}";
+
+        FeatureSet set = new StoredFeatureSet("set", List.of(randomFeature("feat1"), randomFeature("feat2")));
+        assertThat(
+            expectThrows(ParsingException.class, () -> parser.parse(set, model)).getMessage(),
+            CoreMatchers.containsString("Feature names list and feature types list must have the same length")
+        );
+    }
+
+    public void testSplitMissingLeftChild() throws IOException {
+        String model = "{"
+            + "    \"learner\":{"
+            + "        \"attributes\":{},"
+            + "        \"feature_names\":[\"feat1\"],"
+            + "        \"feature_types\":[\"float\"],"
+            + "        \"gradient_booster\":{"
+            + "        \"model\":{"
+            + "            \"gbtree_model_param\":{"
+            + "            \"num_parallel_tree\":\"1\","
+            + "            \"num_trees\":\"1\"},"
+            + "            \"iteration_indptr\":[0,1],"
+            + "            \"tree_info\":[0],"
+            + "            \"trees\":[{"
+            + "                \"base_weights\":[1E0, 10E0, 0E0],"
+            + "                \"categories\":[],"
+            + "                \"categories_nodes\":[],"
+            + "                \"categories_segments\":[],"
+            + "                \"categories_sizes\":[],"
+            + "                \"default_left\":[0, 0, 0],"
+            + "                \"id\":0,"
+            + "                \"left_children\":[100, -1, -1],"
+            + "                \"loss_changes\":[0E0, 0E0, 0E0],"
+            + "                \"parents\":[2147483647, 0, 0],"
+            + "                \"right_children\":[1, -1, -1],"
+            + "                \"split_conditions\":[3E0, -1E0, -1E0],"
+            + "                \"split_indices\":[0, 0, 0],"
+            + "                \"split_type\":[0, 0, 0],"
+            + "                \"sum_hessian\":[1E0, 1E0, 1E0],"
+            + "                \"tree_param\":{"
+            + "                    \"num_deleted\":\"0\","
+            + "                    \"num_feature\":\"1\","
+            + "                    \"num_nodes\":\"3\","
+            + "                    \"size_leaf_vector\":\"1\"}"
+            + "                }"
+            + "            ]},"
+            + "            \"name\":\"gbtree\""
+            + "        },"
+            + "        \"learner_model_param\":{"
+            + "            \"base_score\":\"5E-1\","
+            + "            \"boost_from_average\":\"1\","
+            + "            \"num_class\":\"0\","
+            + "            \"num_feature\":\"1\","
+            + "            \"num_target\":\"1\""
+            + "        },"
+            + "        \"objective\":{"
+            + "            \"name\":\"reg:linear\","
+            + "            \"reg_loss_param\":{\"scale_pos_weight\":\"1\"}"
+            + "        }"
+            + "    },"
+            + "    \"version\":[2,1,0]"
+            + "}";
+
+        try {
+            FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+            parser.parse(set, model);
+            fail("Expected an exception");
+        } catch (ParsingException e) {
+            assertThat(e.getMessage(), CoreMatchers.containsString("Unable to parse XGBoost object"));
+            Throwable rootCause = e.getCause().getCause().getCause().getCause().getCause().getCause();
+            assertThat(rootCause, CoreMatchers.instanceOf(IllegalArgumentException.class));
+            assertThat(rootCause.getMessage(), CoreMatchers.containsString("Child node reference ID [100] is invalid"));
+        }
+    }
+
+    public void testSplitMissingRightChild() throws IOException {
+        String model = "{"
+            + "    \"learner\":{"
+            + "        \"attributes\":{},"
+            + "        \"feature_names\":[\"feat1\"],"
+            + "        \"feature_types\":[\"float\"],"
+            + "        \"gradient_booster\":{"
+            + "        \"model\":{"
+            + "            \"gbtree_model_param\":{"
+            + "            \"num_parallel_tree\":\"1\","
+            + "            \"num_trees\":\"1\"},"
+            + "            \"iteration_indptr\":[0,1],"
+            + "            \"tree_info\":[0],"
+            + "            \"trees\":[{"
+            + "                \"base_weights\":[1E0, 10E0, 0E0],"
+            + "                \"categories\":[],"
+            + "                \"categories_nodes\":[],"
+            + "                \"categories_segments\":[],"
+            + "                \"categories_sizes\":[],"
+            + "                \"default_left\":[0, 0, 0],"
+            + "                \"id\":0,"
+            + "                \"left_children\":[1, -1, -1],"
+            + "                \"loss_changes\":[0E0, 0E0, 0E0],"
+            + "                \"parents\":[2147483647, 0, 0],"
+            + "                \"right_children\":[100, -1, -1],"
+            + "                \"split_conditions\":[3E0, -1E0, -1E0],"
+            + "                \"split_indices\":[0, 0, 0],"
+            + "                \"split_type\":[0, 0, 0],"
+            + "                \"sum_hessian\":[1E0, 1E0, 1E0],"
+            + "                \"tree_param\":{"
+            + "                    \"num_deleted\":\"0\","
+            + "                    \"num_feature\":\"1\","
+            + "                    \"num_nodes\":\"3\","
+            + "                    \"size_leaf_vector\":\"1\"}"
+            + "                }"
+            + "            ]},"
+            + "            \"name\":\"gbtree\""
+            + "        },"
+            + "        \"learner_model_param\":{"
+            + "            \"base_score\":\"5E-1\","
+            + "            \"boost_from_average\":\"1\","
+            + "            \"num_class\":\"0\","
+            + "            \"num_feature\":\"1\","
+            + "            \"num_target\":\"1\""
+            + "        },"
+            + "        \"objective\":{"
+            + "            \"name\":\"reg:linear\","
+            + "            \"reg_loss_param\":{\"scale_pos_weight\":\"1\"}"
+            + "        }"
+            + "    },"
+            + "    \"version\":[2,1,0]"
+            + "}";
+
+        try {
+            FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+            parser.parse(set, model);
+            fail("Expected an exception");
+        } catch (ParsingException e) {
+            assertThat(e.getMessage(), CoreMatchers.containsString("Unable to parse XGBoost object"));
+            Throwable rootCause = e.getCause().getCause().getCause().getCause().getCause().getCause();
+            assertThat(rootCause, CoreMatchers.instanceOf(IllegalArgumentException.class));
+            assertThat(rootCause.getMessage(), CoreMatchers.containsString("Child node reference ID [100] is invalid"));
+        }
+    }
+
+    public void testBadStruct() throws IOException {
+        String model = "[{"
+            + "    \"learner\":{"
+            + "        \"attributes\":{},"
+            + "        \"feature_names\":[\"feat1\", \"feat2\"],"
+            + "        \"feature_types\":[\"float\", \"float\"],"
+            + "        \"gradient_booster\":{"
+            + "        \"model\":{"
+            + "            \"gbtree_model_param\":{"
+            + "            \"num_parallel_tree\":\"1\","
+            + "            \"num_trees\":\"1\"},"
+            + "            \"iteration_indptr\":[0,1],"
+            + "            \"tree_info\":[0],"
+            + "            \"trees\":[{"
+            + "                \"base_weights\":[1E0, 10E0, 0E0],"
+            + "                \"categories\":[],"
+            + "                \"categories_nodes\":[],"
+            + "                \"categories_segments\":[],"
+            + "                \"categories_sizes\":[],"
+            + "                \"default_left\":[0, 0, 0],"
+            + "                \"id\":0,"
+            + "                \"left_children\":[2, -1, -1],"
+            + "                \"loss_changes\":[0E0, 0E0, 0E0],"
+            + "                \"parents\":[2147483647, 0, 0],"
+            + "                \"right_children\":[1, -1, -1],"
+            + "                \"split_conditions\":[3E0, -1E0, -1E0],"
+            + "                \"split_indices\":[0, 0, 0],"
+            + "                \"split_type\":[0, 0, 0],"
+            + "                \"sum_hessian\":[1E0, 1E0, 1E0],"
+            + "                \"tree_param\":{"
+            + "                    \"num_deleted\":\"0\","
+            + "                    \"num_feature\":\"2\","
+            + "                    \"num_nodes\":\"3\","
+            + "                    \"size_leaf_vector\":\"1\"}"
+            + "                }"
+            + "            ]},"
+            + "            \"name\":\"gbtree\""
+            + "        },"
+            + "        \"learner_model_param\":{"
+            + "            \"base_score\":\"5E-1\","
+            + "            \"boost_from_average\":\"1\","
+            + "            \"num_class\":\"0\","
+            + "            \"num_feature\":\"2\","
+            + "            \"num_target\":\"1\""
+            + "        },"
+            + "        \"objective\":{"
+            + "            \"name\":\"reg:linear\","
+            + "            \"reg_loss_param\":{\"scale_pos_weight\":\"1\"}"
+            + "        }"
+            + "    },"
+            + "    \"version\":[2,1,0]"
+            + "}]";
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+        assertThat(
+            expectThrows(ParsingException.class, () -> parser.parse(set, model)).getMessage(),
+            CoreMatchers.containsString("Expected [START_OBJECT] but got")
+        );
+    }
+
+    public void testMissingFeat() throws IOException {
+        String model = "{"
+            + "    \"learner\":{"
+            + "        \"attributes\":{},"
+            + "        \"feature_names\":[\"feat1\", \"feat2\"],"
+            + "        \"feature_types\":[\"float\",\"float\"],"
+            + "        \"gradient_booster\":{"
+            + "        \"model\":{"
+            + "            \"gbtree_model_param\":{"
+            + "            \"num_parallel_tree\":\"1\","
+            + "            \"num_trees\":\"1\"},"
+            + "            \"iteration_indptr\":[0,1],"
+            + "            \"tree_info\":[0],"
+            + "            \"trees\":[{"
+            + "                \"base_weights\":[1E0, 10E0, 0E0],"
+            + "                \"categories\":[],"
+            + "                \"categories_nodes\":[],"
+            + "                \"categories_segments\":[],"
+            + "                \"categories_sizes\":[],"
+            + "                \"default_left\":[0, 0, 0],"
+            + "                \"id\":0,"
+            + "                \"left_children\":[2, -1, -1],"
+            + "                \"loss_changes\":[0E0, 0E0, 0E0],"
+            + "                \"parents\":[2147483647, 0, 0],"
+            + "                \"right_children\":[1, -1, -1],"
+            + "                \"split_conditions\":[3E0, -1E0, -1E0],"
+            + "                \"split_indices\":[0, 0, 100],"
+            + "                \"split_type\":[0, 0, 0],"
+            + "                \"sum_hessian\":[1E0, 1E0, 1E0],"
+            + "                \"tree_param\":{"
+            + "                    \"num_deleted\":\"0\","
+            + "                    \"num_feature\":\"2\","
+            + "                    \"num_nodes\":\"3\","
+            + "                    \"size_leaf_vector\":\"1\"}"
+            + "                }"
+            + "            ]},"
+            + "            \"name\":\"gbtree\""
+            + "        },"
+            + "        \"learner_model_param\":{"
+            + "            \"base_score\":\"5E-1\","
+            + "            \"boost_from_average\":\"1\","
+            + "            \"num_class\":\"0\","
+            + "            \"num_feature\":\"2\","
+            + "            \"num_target\":\"1\""
+            + "        },"
+            + "        \"objective\":{"
+            + "            \"name\":\"reg:linear\","
+            + "            \"reg_loss_param\":{\"scale_pos_weight\":\"1\"}"
+            + "        }"
+            + "    },"
+            + "    \"version\":[2,1,0]"
+            + "}";
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1234")));
+        assertThat(
+            expectThrows(ParsingException.class, () -> parser.parse(set, model)).getMessage(),
+            CoreMatchers.containsString("Unknown features in model: [feat1, feat2]")
+        );
+    }
+
+    public void testMultiTreeEnsemble() throws IOException {
+        String model = "{"
+            + "    \"learner\":{"
+            + "        \"attributes\":{},"
+            + "        \"feature_names\":[\"feat1\", \"feat2\"],"
+            + "        \"feature_types\":[\"float\", \"float\"],"
+            + "        \"gradient_booster\":{"
+            + "        \"model\":{"
+            + "            \"gbtree_model_param\":{"
+            + "            \"num_parallel_tree\":\"1\","
+            + "            \"num_trees\":\"2\"},"
+            + "            \"iteration_indptr\":[0,1,2],"
+            + "            \"tree_info\":[0, 1],"
+            + "            \"trees\":[{"
+            + "                \"base_weights\":[1E0, 10E0, 0E0],"
+            + "                \"categories\":[],"
+            + "                \"categories_nodes\":[],"
+            + "                \"categories_segments\":[],"
+            + "                \"categories_sizes\":[],"
+            + "                \"default_left\":[0, 0, 0],"
+            + "                \"id\":0,"
+            + "                \"left_children\":[2, -1, -1],"
+            + "                \"loss_changes\":[0E0, 0E0, 0E0],"
+            + "                \"parents\":[2147483647, 0, 0],"
+            + "                \"right_children\":[1, -1, -1],"
+            + "                \"split_conditions\":[3E0, -1E0, -1E0],"
+            + "                \"split_indices\":[0, 0, 0],"
+            + "                \"split_type\":[0, 0, 0],"
+            + "                \"sum_hessian\":[1E0, 1E0, 1E0],"
+            + "                \"tree_param\":{"
+            + "                    \"num_deleted\":\"0\","
+            + "                    \"num_feature\":\"2\","
+            + "                    \"num_nodes\":\"3\","
+            + "                    \"size_leaf_vector\":\"1\"}"
+            + "                },"
+            + "                {"
+            + "                \"base_weights\":[1E0, 5E0, 0E0],"
+            + "                \"categories\":[],"
+            + "                \"categories_nodes\":[],"
+            + "                \"categories_segments\":[],"
+            + "                \"categories_sizes\":[],"
+            + "                \"default_left\":[0, 0, 0],"
+            + "                \"id\":1,"
+            + "                \"left_children\":[2, -1, -1],"
+            + "                \"loss_changes\":[0E0, 0E0, 0E0],"
+            + "                \"parents\":[2147483647, 0, 0],"
+            + "                \"right_children\":[1, -1, -1],"
+            + "                \"split_conditions\":[3E0, -1E0, -1E0],"
+            + "                \"split_indices\":[1, 1, 1],"
+            + "                \"split_type\":[0, 0, 0],"
+            + "                \"sum_hessian\":[1E0, 1E0, 1E0],"
+            + "                \"tree_param\":{"
+            + "                    \"num_deleted\":\"0\","
+            + "                    \"num_feature\":\"2\","
+            + "                    \"num_nodes\":\"3\","
+            + "                    \"size_leaf_vector\":\"1\"}"
+            + "                }"
+            + "            ]},"
+            + "            \"name\":\"gbtree\""
+            + "        },"
+            + "        \"learner_model_param\":{"
+            + "            \"base_score\":\"5E-1\","
+            + "            \"boost_from_average\":\"1\","
+            + "            \"num_class\":\"0\","
+            + "            \"num_feature\":\"2\","
+            + "            \"num_target\":\"1\""
+            + "        },"
+            + "        \"objective\":{"
+            + "            \"name\":\"reg:linear\","
+            + "            \"reg_loss_param\":{\"scale_pos_weight\":\"1\"}"
+            + "        }"
+            + "    },"
+            + "    \"version\":[2,1,0]"
+            + "}";
+
+        FeatureSet set = new StoredFeatureSet("set", List.of(randomFeature("feat1"), randomFeature("feat2")));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        FeatureVector featureVector = tree.newFeatureVector(null);
+        featureVector.setFeatureScore(0, 2);
+        featureVector.setFeatureScore(1, 2);
+        assertEquals(0.0, tree.score(featureVector), Math.ulp(0.1F));
+
+        featureVector.setFeatureScore(0, 4);
+        featureVector.setFeatureScore(1, 4);
+        assertEquals(15.0, tree.score(featureVector), Math.ulp(0.1F));
+    }
+
+    public void testFeatureReordering() throws IOException {
+        String model = "{"
+            + "    \"learner\":{"
+            + "        \"attributes\":{},"
+            + "        \"feature_names\":[\"feat1\", \"feat2\"],"
+            + "        \"feature_types\":[\"float\", \"float\"],"
+            + "        \"gradient_booster\":{"
+            + "        \"model\":{"
+            + "            \"gbtree_model_param\":{"
+            + "            \"num_parallel_tree\":\"1\","
+            + "            \"num_trees\":\"1\"},"
+            + "            \"iteration_indptr\":[0,1],"
+            + "            \"tree_info\":[0],"
+            + "            \"trees\":[{"
+            + "                \"base_weights\":[1E0, 10E0, 0E0],"
+            + "                \"categories\":[],"
+            + "                \"categories_nodes\":[],"
+            + "                \"categories_segments\":[],"
+            + "                \"categories_sizes\":[],"
+            + "                \"default_left\":[0, 0, 0],"
+            + "                \"id\":0,"
+            + "                \"left_children\":[2, -1, -1],"
+            + "                \"loss_changes\":[0E0, 0E0, 0E0],"
+            + "                \"parents\":[2147483647, 0, 0],"
+            + "                \"right_children\":[1, -1, -1],"
+            + "                \"split_conditions\":[3E0, -1E0, -1E0],"
+            + "                \"split_indices\":[0, 0, 0],"
+            + "                \"split_type\":[0, 0, 0],"
+            + "                \"sum_hessian\":[1E0, 1E0, 1E0],"
+            + "                \"tree_param\":{"
+            + "                    \"num_deleted\":\"0\","
+            + "                    \"num_feature\":\"2\","
+            + "                    \"num_nodes\":\"3\","
+            + "                    \"size_leaf_vector\":\"1\"}"
+            + "                }"
+            + "            ]},"
+            + "            \"name\":\"gbtree\""
+            + "        },"
+            + "        \"learner_model_param\":{"
+            + "            \"base_score\":\"5E-1\","
+            + "            \"boost_from_average\":\"1\","
+            + "            \"num_class\":\"0\","
+            + "            \"num_feature\":\"2\","
+            + "            \"num_target\":\"1\""
+            + "        },"
+            + "        \"objective\":{"
+            + "            \"name\":\"reg:linear\","
+            + "            \"reg_loss_param\":{\"scale_pos_weight\":\"1\"}"
+            + "        }"
+            + "    },"
+            + "    \"version\":[2,1,0]"
+            + "}";
+
+        FeatureSet set = new StoredFeatureSet("set", List.of(randomFeature("feat2"), randomFeature("feat1")));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        FeatureVector featureVector = tree.newFeatureVector(null);
+        featureVector.setFeatureScore(0, 4); // feat2
+        featureVector.setFeatureScore(1, 2); // feat1
+        assertEquals(0.0, tree.score(featureVector), Math.ulp(0.1F));
+
+        FeatureSet setNoReorder = new StoredFeatureSet("set", List.of(randomFeature("feat1"), randomFeature("feat2")));
+        NaiveAdditiveDecisionTree treeNoReorder = parser.parse(setNoReorder, model);
+        FeatureVector featureVectorNoReorder = treeNoReorder.newFeatureVector(null);
+        featureVectorNoReorder.setFeatureScore(0, 2); // feat1
+        featureVectorNoReorder.setFeatureScore(1, 4); // feat2
+        assertEquals(0.0, treeNoReorder.score(featureVectorNoReorder), Math.ulp(0.1F));
+    }
+}


### PR DESCRIPTION
### Description
Backport of PR: #151 
The LTR plugin is currently using the wrong method of loading xgboost models: it expects the output format of the [get_dump](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/get_dump) method, which is only meant for representation purposes e.g. plotting. This PR adds a parser for the output format of the [save_model](https://xgboost.readthedocs.io/en/stable/python/python_api.html#xgboost.Booster.save_model) method.

A quote from the xgboost's documentation:

get_dump: Returns the model dump as a list of strings. Unlike [save_model()](https://xgboost.readthedocs.io/en/stable/python/python_api.html#xgboost.Booster.save_model), the output format is primarily used for visualization or interpretation, hence it’s more human readable but cannot be loaded back to XGBoost.

This PR is a port of the following patch: https://github.com/o19s/elasticsearch-learning-to-rank/pull/500

### Issues Resolved
The original issue in the o19s LTR plugin's repo: https://github.com/o19s/elasticsearch-learning-to-rank/issues/497

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
