### PR TITLE
Support phasing off SecurityManager usage in favor of Java Agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,15 @@ dependencies {
   runtimeOnly 'org.locationtech.spatial4j:spatial4j:0.7'
   runtimeOnly 'org.locationtech.jts:jts-core:1.15.0'
   runtimeOnly 'org.apache.logging.log4j:log4j-core:2.21.0'
+
+  
+  agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
+  agent "org.opensearch:opensearch-agent:${opensearch_version}"
+  agent "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
+}
+
+configurations {
+  agent
 }
 
 configurations.all {
@@ -246,6 +255,16 @@ tasks.withType(Test).configureEach { task ->
   tasks.named(taskName).configure {
     enabled = false
   }
+}
+
+task prepareAgent(type: Copy) {
+  from(configurations.agent)
+  into "$buildDir/agent"
+}
+
+tasks.withType(Test) {
+    dependsOn prepareAgent
+    jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
 }
 
 tasks.named('dependencyLicenses') {

--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,6 @@ dependencies {
   runtimeOnly 'org.locationtech.spatial4j:spatial4j:0.7'
   runtimeOnly 'org.locationtech.jts:jts-core:1.15.0'
   runtimeOnly 'org.apache.logging.log4j:log4j-core:2.21.0'
-
   
   agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
   agent "org.opensearch:opensearch-agent:${opensearch_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,10 @@ repositories {
   maven { url "https://plugins.gradle.org/m2/" }
 }
 
+configurations {
+  agent
+}
+
 dependencies {
   implementation "org.apache.lucene:lucene-expressions:${luceneVersion}"
   implementation "org.antlr:antlr4-runtime:${antlrVersion}"
@@ -142,10 +146,6 @@ dependencies {
   agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
   agent "org.opensearch:opensearch-agent:${opensearch_version}"
   agent "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
-}
-
-configurations {
-  agent
 }
 
 configurations.all {


### PR DESCRIPTION
### Description
Support phasing off SecurityManager usage in favor of Java Agent

This commit allows passing a JVM argument to allow plugins test execute under Java Agent.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
