### PR TITLE
[Backport 2.19] Address http5client CVE, use core's dependency (#171)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,9 +126,6 @@ dependencies {
   implementation "org.ow2.asm:asm-tree:${ow2Version}"
   implementation 'com.o19s:RankyMcRankFace:0.1.1'
   implementation "com.github.spullara.mustache.java:compiler:0.9.3"
-  implementation "org.apache.httpcomponents.client5:httpclient5:5.3.1"
-  implementation "org.apache.httpcomponents.core5:httpcore5:5.3"
-  implementation "org.apache.httpcomponents.core5:httpcore5-h2:5.3"
   implementation "org.conscrypt:conscrypt-openjdk-uber:2.5.2"
   implementation 'org.slf4j:slf4j-api:1.7.36'
   implementation 'org.slf4j:slf4j-simple:1.7.36'
@@ -140,10 +137,6 @@ dependencies {
 }
 
 configurations.all {
-  resolutionStrategy.force "org.apache.httpcomponents.client5:httpclient5:5.3.1"
-  resolutionStrategy.force "org.apache.httpcomponents.core5:httpcore5:5.3"
-  resolutionStrategy.force "org.apache.httpcomponents.core5:httpcore5-h2:5.3"
-  resolutionStrategy.force 'org.apache.httpcomponents:httpclient:4.5.14'
   resolutionStrategy.force "com.google.guava:guava:32.1.3-jre"
   resolutionStrategy.force 'org.eclipse.platform:org.eclipse.core.runtime:3.29.0'
 }


### PR DESCRIPTION
### Description
Use Core's implementation of `httpclient5` and `httpcore5` instead of custom dependency.


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
