### PR TITLE
Lucene 10.2 upgrade changes

### DIFF
--- a/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
+++ b/src/main/java/com/o19s/es/ltr/query/RankerQuery.java
@@ -345,7 +345,7 @@ public class RankerQuery extends Query {
 
         public RankerScorer getScorer(LeafReaderContext context) throws IOException {
             List<Scorer> scorers = new ArrayList<>(weights.size());
-            DisiPriorityQueue disiPriorityQueue = new DisiPriorityQueue(weights.size());
+            DisiPriorityQueue disiPriorityQueue = DisiPriorityQueue.ofMaxSize(weights.size());
             for (Weight weight : weights) {
                 Scorer scorer = weight.scorer(context);
                 if (scorer == null) {


### PR DESCRIPTION
### Description
With openSearch 3.1, we moved to lucene 10.2

DisiPriorityQueue's initialization has changed as below.
### Issues Resolved https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/184

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
