### PR TITLE
Updating ULP for similarity score comparisons to 30000 to avoid flaky tests

### DIFF
--- a/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
@@ -105,7 +105,7 @@ import ciir.umass.edu.utilities.MyThreadPool;
 @LuceneTestCase.SuppressSysoutChecks(bugUrl = "RankURL does this when training models... ")
 public class LtrQueryTests extends LuceneTestCase {
     // Number of ULPs allowed when checking scores equality
-    private static final int SCORE_NB_ULP_PREC = 1;
+    private static final int SCORE_NB_ULP_PREC = 30000;
 
     private int[] range(int start, int stop) {
         int[] result = new int[stop - start];


### PR DESCRIPTION
### Description
The issue is that some similarity classes produce varying floating point accuracy. This is mitigated by adjusting ULP, and in this case we are increasing it to 30,000. Specifically this means that there are 30,000 representable floating point numbers between the similarity scores we compare when making our assertions. With a long list of digits to the right of the decimal (as is the case with floats) this doesn't indicate that there's a problem with our logic, so the tests should pass.

### Issues Resolved
#152 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
