### PR TITLE
Downgrade codecov upload, bump Windows Java to 24

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,4 +91,4 @@ jobs:
       - name: Build and Run Tests
         shell: bash
         run: |
-          ./gradlew.bat build -x spotlessJava
+          ./gradlew.bat -Dtests.security.manager=false build -x spotlessJava


### PR DESCRIPTION
### Description
Codecov on amazon linux needs a lower version for now, so downgrading this from 5 to 3. Also, when I updated the JVM CI matrix I missed the Windows matrix for testing, so this corrects that omission.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
