### PR TITLE
Change QueryRescorer.QueryRescoreContext query processing as per changes in core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
 
   repositories {
     mavenLocal()
+    maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
@@ -101,7 +102,7 @@ publishing {
     }
     maven {
       name = "Snapshots"
-      url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+      url = "https://central.sonatype.com/repository/maven-snapshots/"
       credentials {
         username "$System.env.SONATYPE_USERNAME"
         password "$System.env.SONATYPE_PASSWORD"
@@ -114,6 +115,7 @@ publishing {
 // OpenSearch dependency is included due to the build-tools, test-framework as well
 repositories {
   mavenLocal()
+  maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
   maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
   mavenCentral()
   maven { url "https://plugins.gradle.org/m2/" }

--- a/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
+++ b/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java
@@ -124,12 +124,12 @@ public class LoggingFetchSubPhase implements FetchSubPhase {
         QueryRescorer.QueryRescoreContext qrescore = (QueryRescorer.QueryRescoreContext) context;
         return toLogger(
             logSpec,
-            inspectQuery(qrescore.query())
+            inspectQuery(qrescore.parsedQuery().query())
                 .orElseThrow(
                     () -> new IllegalArgumentException(
                         "Expected a [sltr] query but found a "
                             + "["
-                            + qrescore.query().getClass().getSimpleName()
+                            + qrescore.parsedQuery().query().getClass().getSimpleName()
                             + "] "
                             + "at index ["
                             + logSpec.getRescoreIndex()


### PR DESCRIPTION
### Description
With these latest changes from Core: https://github.com/opensearch-project/OpenSearch/pull/18697 the build of LTR fails with this error:
```
> Task :compileJava
/tmp/tmp7o2tt_my/opensearch-learning-to-rank-base/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java:127: error: cannot find symbol
            inspectQuery(qrescore.query())
                                 ^
  symbol:   method query()
  location: variable qrescore of type QueryRescoreContext
/tmp/tmp7o2tt_my/opensearch-learning-to-rank-base/src/main/java/com/o19s/es/ltr/logging/LoggingFetchSubPhase.java:132: error: cannot find symbol
                            + qrescore.query().getClass().getSimpleName()
``` 

This PR fixes these errors.

This issue was not surfaced before because it was pulling the older version on opensearch snapshots. Updated the build.gradle to get the latest snapshots

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
