### PR TITLE
Add XGBoost parsing support for objectives `rank:ndcg` and `rank:map`

### DIFF
--- a/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
@@ -123,6 +123,8 @@ public class XGBoostJsonParser implements LtrRankerParser {
         void setNormalizer(String objectiveName) {
             switch (objectiveName) {
                 case "binary:logitraw":
+                case "rank:ndcg":
+                case "rank:map":
                 case "rank:pairwise":
                 case "reg:linear":
                     normalizer = Normalizers.get(Normalizers.NOOP_NORMALIZER_NAME);

--- a/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
@@ -129,6 +129,60 @@ public class XGBoostJsonParserTests extends LuceneTestCase {
         assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
     }
 
+    public void testReadSimpleSplitWithNdcgObjective() throws IOException {
+        String model = "{"
+            + "\"objective\": \"rank:ndcg\","
+            + "\"splits\": [{"
+            + "   \"nodeid\": 0,"
+            + "   \"split\":\"feat1\","
+            + "   \"depth\":0,"
+            + "   \"split_condition\":0.123,"
+            + "   \"yes\":1,"
+            + "   \"no\": 2,"
+            + "   \"missing\":2,"
+            + "   \"children\": ["
+            + "      {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5},"
+            + "      {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
+            + "]}]}";
+
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        FeatureVector v = tree.newFeatureVector(null);
+        v.setFeatureScore(0, 0.124F);
+        assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
+        v.setFeatureScore(0, 0.122F);
+        assertEquals(0.5F, tree.score(v), Math.ulp(0.5F));
+        v.setFeatureScore(0, 0.123F);
+        assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
+    }
+
+    public void testReadSimpleSplitWithMapObjective() throws IOException {
+        String model = "{"
+            + "\"objective\": \"rank:ndcg\","
+            + "\"splits\": [{"
+            + "   \"nodeid\": 0,"
+            + "   \"split\":\"feat1\","
+            + "   \"depth\":0,"
+            + "   \"split_condition\":0.123,"
+            + "   \"yes\":1,"
+            + "   \"no\": 2,"
+            + "   \"missing\":2,"
+            + "   \"children\": ["
+            + "      {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5},"
+            + "      {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
+            + "]}]}";
+
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        FeatureVector v = tree.newFeatureVector(null);
+        v.setFeatureScore(0, 0.124F);
+        assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
+        v.setFeatureScore(0, 0.122F);
+        assertEquals(0.5F, tree.score(v), Math.ulp(0.5F));
+        v.setFeatureScore(0, 0.123F);
+        assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
+    }
+
     public void testReadSplitWithUnknownParams() throws IOException {
         String model = "{"
             + "\"not_param\": \"value\","


### PR DESCRIPTION
### Description
When attempting to use rank:ndcg as an objective model deployment failed unexpectedly, stating that the objective was invalid.

As per the [XGBoost docs](https://github.com/dmlc/xgboost/blob/1094d6015df7be6f5829e53a4c257f3481b43ee5/doc/parameter.rst#parameters-for-learning-to-rank-rank-ndcg-rank-map-rank-pairwise) rank:ndcg and rank:map are valid objectives, but are currently rejected by the parser.

This change resolves this by extending the list of objectives which map to the no-op normalizer, allowing the models to be parsed and used by the plugin.

ES LTR PR and description by @styrmis: https://github.com/o19s/elasticsearch-learning-to-rank/pull/479

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
