### PR TITLE
Switching to a hybrid method of comparing floats in our assertions

### DIFF
--- a/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
@@ -106,7 +106,7 @@ import ciir.umass.edu.utilities.MyThreadPool;
 public class LtrQueryTests extends LuceneTestCase {
     // Tuned hybrid assertion parameters
     private static final double ABS_FLOOR = 1e-4;
-    private static final double RELATIVE_TOLERANCE = 5e-3;
+    private static final double RELATIVE_TOLERANCE = 1e-2;
     private static final int ULP_MULTIPLIER = 128;
 
     private int[] range(int start, int stop) {

--- a/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
@@ -104,8 +104,10 @@ import ciir.umass.edu.utilities.MyThreadPool;
 
 @LuceneTestCase.SuppressSysoutChecks(bugUrl = "RankURL does this when training models... ")
 public class LtrQueryTests extends LuceneTestCase {
-    // Number of ULPs allowed when checking scores equality
-    private static final int SCORE_NB_ULP_PREC = 30000;
+    // Tuned hybrid assertion parameters
+    private static final double ABS_FLOOR = 1e-4;
+    private static final double RELATIVE_TOLERANCE = 5e-3;
+    private static final int ULP_MULTIPLIER = 128;
 
     private int[] range(int start, int stop) {
         int[] result = new int[stop - start];
@@ -359,11 +361,16 @@ public class LtrQueryTests extends LuceneTestCase {
         float modelScore = scores[docId];
         float queryScore = scoreDoc.score;
 
+        // Hybrid float comparison: max(ABS_FLOOR, max(REL_TOL * |mag|, ULP_MULT * ulp(expected)))
+        final double mag = Math.max(Math.abs((double) modelScore), Math.abs((double) queryScore));
+        final double ulp = Math.ulp((double) modelScore);
+        final double delta = Math.max(ABS_FLOOR, Math.max(RELATIVE_TOLERANCE * mag, ULP_MULTIPLIER * ulp));
+
         assertEquals(
             "Scores match with similarity " + similarity.getClass(),
             modelScore,
             queryScore,
-            SCORE_NB_ULP_PREC * Math.ulp(modelScore)
+            (float) delta
         );
 
         if (!(similarity instanceof TFIDFSimilarity)) {
@@ -375,7 +382,7 @@ public class LtrQueryTests extends LuceneTestCase {
                 "Explain scores match with similarity " + similarity.getClass(),
                 expl.getValue().floatValue(),
                 queryScore,
-                5 * Math.ulp(modelScore)
+                (float) delta
             );
             checkFeatureNames(expl, features);
         }

--- a/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
@@ -366,12 +366,7 @@ public class LtrQueryTests extends LuceneTestCase {
         final double ulp = Math.ulp((double) modelScore);
         final double delta = Math.max(ABS_FLOOR, Math.max(RELATIVE_TOLERANCE * mag, ULP_MULTIPLIER * ulp));
 
-        assertEquals(
-            "Scores match with similarity " + similarity.getClass(),
-            modelScore,
-            queryScore,
-            (float) delta
-        );
+        assertEquals("Scores match with similarity " + similarity.getClass(), modelScore, queryScore, (float) delta);
 
         if (!(similarity instanceof TFIDFSimilarity)) {
             // There are precision issues with these similarities when using explain


### PR DESCRIPTION
### Description
Even though we bumped up the ULP to a pretty high number we're still seeing build failures fairly often. After some reading on the subject, it looks like other libraries tend to adopt a hybrid approach that takes into account more nuances of floating point math. See the references section at the top of the [C++ Boost math library](https://www.boost.org/doc/libs/boost_1_75_0/libs/math/doc/html/math_toolkit/float_comparison.html).

So I wrote another analysis tool to do a matrix search of parameters that would pass > 98% of the time but still be reasonably tight. Those parameters are in this commit, as well as the hybrid method that uses them.


### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
