### PR TITLE
Bump SLF4J to 2.0.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,8 +130,8 @@ dependencies {
   implementation 'com.o19s:RankyMcRankFace:0.1.1'
   implementation "com.github.spullara.mustache.java:compiler:0.9.3"
   implementation "org.conscrypt:conscrypt-openjdk-uber:2.5.2"
-  implementation 'org.slf4j:slf4j-api:1.7.36'
-  implementation 'org.slf4j:slf4j-simple:1.7.36'
+  implementation 'org.slf4j:slf4j-api:2.0.17'
+  testImplementation 'org.slf4j:slf4j-simple:2.0.17'
   implementation "org.opensearch:common-utils:${common_utils_version}"
 
   runtimeOnly 'org.locationtech.spatial4j:spatial4j:0.7'
@@ -142,6 +142,7 @@ dependencies {
 configurations.configureEach {
   resolutionStrategy.force "com.google.guava:guava:32.1.3-jre"
   resolutionStrategy.force 'org.eclipse.platform:org.eclipse.core.runtime:3.29.0'
+  resolutionStrategy.force 'org.slf4j:slf4j-api:2.0.17'
 }
 
 // see https://github.com/opensearch-project/OpenSearch/blob/0ba0e7cc26060f964fcbf6ee45bae53b3a9941d0/buildSrc/src/main/java/org/opensearch/gradle/precommit/DependencyLicensesTask.java


### PR DESCRIPTION

### Description
Building with 3.3.0-SNAPSHOT fails due to SLF version conflict.
Move binding to test scope to resolve conflict with OpenSearch 3.3 deps.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
