### PR TITLE
Fix bad inclusion of log4j in this jar when bundled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,7 @@ configurations.configureEach {
   resolutionStrategy.force "com.google.guava:guava:32.1.3-jre"
   resolutionStrategy.force 'org.eclipse.platform:org.eclipse.core.runtime:3.29.0'
   resolutionStrategy.force 'org.slf4j:slf4j-api:2.0.17'
+  resolutionStrategy.force 'com.google.errorprone:error_prone_annotations:2.41.0'
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -136,13 +136,20 @@ dependencies {
 
   runtimeOnly 'org.locationtech.spatial4j:spatial4j:0.7'
   runtimeOnly 'org.locationtech.jts:jts-core:1.15.0'
-  runtimeOnly 'org.apache.logging.log4j:log4j-core:2.21.0'
 }
 
 configurations.configureEach {
   resolutionStrategy.force "com.google.guava:guava:32.1.3-jre"
   resolutionStrategy.force 'org.eclipse.platform:org.eclipse.core.runtime:3.29.0'
   resolutionStrategy.force 'org.slf4j:slf4j-api:2.0.17'
+}
+
+configurations {
+  runtimeClasspath {
+    exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
+    exclude group: 'org.apache.logging.log4j', module: 'log4j-api'
+    exclude group: 'org.apache.logging.log4j', module: 'log4j-jul'
+  }
 }
 
 // see https://github.com/opensearch-project/OpenSearch/blob/0ba0e7cc26060f964fcbf6ee45bae53b3a9941d0/buildSrc/src/main/java/org/opensearch/gradle/precommit/DependencyLicensesTask.java


### PR DESCRIPTION
### Description
Log4j is being included in the plugin jar, which causes jar hell when OpenSearch itself is bundled.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
