### PR TITLE
Adding code coverage report generation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,11 +65,12 @@ jobs:
         run: |
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c 'whoami && java -version &&
-                              ./gradlew -Dtests.security.manager=false clean test -x spotlessJava'
+                              ./gradlew -Dtests.security.manager=false clean test jacocoTestReport -x spotlessJava'
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v3
         with:
+            files: build/reports/jacoco/test/jacocoTestReport.xml
             token: ${{ secrets.CODECOV_TOKEN }}
 
   Build-ltr-windows:

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ plugins {
   id 'java'
   id 'idea'
   id 'maven-publish'
+  id 'jacoco'
   id 'com.diffplug.spotless' version '6.25.0' apply false
 }
 
@@ -280,7 +281,7 @@ tasks.named("run").configure {
     getClusters().add(testClusters.named("integTest").get())
 }
 
-// updateVersion: Task to auto update version to the next development iteration
+/* updateVersion: Task to auto update version to the next development iteration */
 tasks.register('updateVersion') {
     onlyIf { System.getProperty('newVersion') }
     doLast {
@@ -288,5 +289,14 @@ tasks.register('updateVersion') {
         println "Setting version to ${newVersion}."
         // String tokenization to support -SNAPSHOT
         ant.replaceregexp(file: 'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags: 'g', byline: true)
+    }
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = false
     }
 }


### PR DESCRIPTION
### Description
Adds code coverage report generation to CI and configures gradle to generate the XML report.

### Issues Resolved
Closes #227 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
