### PR TITLE
Bug/ml index warning

### DIFF
--- a/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
+++ b/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
@@ -18,7 +18,8 @@ setup:
         body: { "field1": "v1 aoeu", "field2": " ua u v2", "field3": "foo bar text", "user_rating": 0.0 }
 
   - do:
-      indices.refresh: { test }
+      indices.refresh:
+        index: test
 
   - do:
       ltr.create_store: {}


### PR DESCRIPTION
### Description
We have been seeing areas where our yaml tests trigger a warning about accessing internal indexes like the `.plugins-ml-config` index. We're not directly doing this but some tests had been refreshing *all* indexes which may have triggered this warning. We've gone through several points where this may happen but we saw the warning (and subsequent test error) again at the point where we refresh the test index after inserting two test docs.

This error is a little more subtle. The way the yaml gets parsed for this currently failing test, the "indices.refresh" command gets an _argument_ of `test` (that is `null`), instead of `test` being the value of the `index` parameter. The effect would be for *no* index to be specified as an argument, which means OS should refresh _all_ indexes.

That's my theory anyway. I'm having a lot of trouble reproducing the error.

### Issues Resolved
Closes #265

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
