### PR TITLE
Use implicit wait_for instead of explicit refresh to avoid warnings about touching system indexes

### DIFF
--- a/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
+++ b/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
@@ -10,16 +10,14 @@ setup:
         index: test
         id: 1
         body: { "field1": "v1", "field2": "v2", "field3": "some text", "user_rating": 5.2 }
+        refresh: wait_for
 
   - do:
       index:
         index: test
         id: 2
         body: { "field1": "v1 aoeu", "field2": " ua u v2", "field3": "foo bar text", "user_rating": 0.0 }
-
-  - do:
-      indices.refresh:
-        index: test
+        refresh: wait_for
 
   - do:
       ltr.create_store: {}


### PR DESCRIPTION
### Description
This is a follow-up to PR #269. We're still getting exceptions in the integration tests run by Jenkins. The exception happens during the rest tests, and it seems right where we ask OS to refresh after adding some test docs. The referenced PR attempted to limit the scope of the refresh to just the test index, but still that line causes OS to warn about touching the ml-config system index.

So instead of doing an explicit refresh I'm going to try waiting for the implicit refresh to happen. That might be an issue if the test is run in a serverless configuration according to [this post](https://repost.aws/questions/QUSYfaKYMzTn2dUPr-oW9maA/aws-opensearch-serverless-supports-for-refresh-wait-for-and-refresh-true). But this is just a test so it wouldn't affect the actual running of LTR in serverless.


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
