### PR TITLE
Fix failing IT `unexpected warning header`

### DIFF
--- a/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
+++ b/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
@@ -146,7 +146,11 @@ teardown:
 
 ---
 "three feature linear model using one active feature":
+  - skip:
+      features: allowed_warnings
   - do:
+      allowed_warnings:
+        - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
       search:
         index: test
         body: { query: { "sltr": { "params": {}, "model": "three_feature_linear_model", "active_features": ["no_param_feature"] } } }


### PR DESCRIPTION
### Description
Fix failing IT `unexpected warning header`

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/265

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
