### PR TITLE
Force error_prone_annotations to 2.41.0 to resolve dependency conflict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,6 +139,7 @@ dependencies {
 configurations.all {
   resolutionStrategy.force "com.google.guava:guava:32.1.3-jre"
   resolutionStrategy.force 'org.eclipse.platform:org.eclipse.core.runtime:3.29.0'
+  resolutionStrategy.force 'com.google.errorprone:error_prone_annotations:2.41.0'
 }
 
 configurations {


### PR DESCRIPTION
  ### Description
 - Completes the backport of #226 to 2.19 branch by adding the missing `error_prone_annotations`
  resolution strategy.
- PR #297 backported #226 (log4j jar hell fix) to 2.19, but during merge conflict resolution, the
  `error_prone_annotations` force line was accidentally omitted.
- Force `error_prone_annotations` to version 2.41.0, matching the original fix in #226 on main branch.

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
