### PR TITLE
Fix Windows CI build failure caused by Spotless P2 mirror timeout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -270,7 +270,7 @@ plugins.withId('com.diffplug.spotless') {
     java {
       removeUnusedImports()
       importOrder 'java', 'javax', 'org', 'com'
-      eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('.eclipseformat.xml')
+      eclipse().configFile rootProject.file('.eclipseformat.xml')
     }
   }
 }


### PR DESCRIPTION
## Summary

Backport of #303 to `main`.

- Removes `withP2Mirrors()` from Spotless Eclipse formatter config so it resolves from Maven Central instead of P2 mirror sites
- Fixes Windows CI build failure caused by `download.eclipse.org` / `mirror.umd.edu` being unreachable from Windows Docker containers in Jenkins

## Test plan

- [ ] Verify Windows CI build passes on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)