### PR TITLE
Make ltr.caches settings dynamically configurable

### DIFF
--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -313,6 +313,10 @@ public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, Script
 
         LTRSettings.getInstance().init(clusterService);
 
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(Caches.LTR_CACHE_MEM_SETTING, caches::setMaxMem);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(Caches.LTR_CACHE_EXPIRE_AFTER_WRITE, caches::setExpireAfterWrite);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(Caches.LTR_CACHE_EXPIRE_AFTER_READ, caches::setExpireAfterAccess);
+
         final JvmService jvmService = new JvmService(environment.settings());
         final LTRCircuitBreakerService ltrCircuitBreakerService = new LTRCircuitBreakerService(jvmService).init();
 

--- a/src/main/java/com/o19s/es/ltr/feature/store/index/Caches.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/index/Caches.java
@@ -27,6 +27,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.common.CheckedFunction;
@@ -46,15 +48,29 @@ import com.o19s.es.ltr.feature.store.CompiledLtrModel;
  * Store various caches used by the plugin
  */
 public class Caches {
+    private static final Logger logger = LogManager.getLogger(Caches.class);
+
     public static final Setting<ByteSizeValue> LTR_CACHE_MEM_SETTING;
     public static final Setting<TimeValue> LTR_CACHE_EXPIRE_AFTER_WRITE = Setting
-        .timeSetting("ltr.caches.expire_after_write", TimeValue.timeValueHours(1), TimeValue.timeValueNanos(0), Setting.Property.NodeScope);
+        .timeSetting(
+            "ltr.caches.expire_after_write",
+            TimeValue.timeValueHours(1),
+            TimeValue.timeValueNanos(0),
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
     public static final Setting<TimeValue> LTR_CACHE_EXPIRE_AFTER_READ = Setting
-        .timeSetting("ltr.caches.expire_after_read", TimeValue.timeValueHours(1), TimeValue.timeValueNanos(0), Setting.Property.NodeScope);
+        .timeSetting(
+            "ltr.caches.expire_after_read",
+            TimeValue.timeValueHours(1),
+            TimeValue.timeValueNanos(0),
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
 
-    private final Cache<CacheKey, Feature> featureCache;
-    private final Cache<CacheKey, FeatureSet> featureSetCache;
-    private final Cache<CacheKey, CompiledLtrModel> modelCache;
+    private volatile Cache<CacheKey, Feature> featureCache;
+    private volatile Cache<CacheKey, FeatureSet> featureSetCache;
+    private volatile Cache<CacheKey, CompiledLtrModel> modelCache;
 
     static {
         LTR_CACHE_MEM_SETTING = Setting
@@ -62,26 +78,62 @@ public class Caches {
                 "ltr.caches.max_mem",
                 (s) -> new ByteSizeValue(Math.min(RamUsageEstimator.ONE_MB * 10, JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() / 10))
                     .toString(),
-                Setting.Property.NodeScope
+                Setting.Property.NodeScope,
+                Setting.Property.Dynamic
             );
     }
     private final Map<String, PerStoreStats> perStoreStats = new ConcurrentHashMap<>();
-    private final long maxWeight;
+    private volatile TimeValue expireAfterWrite;
+    private volatile TimeValue expireAfterAccess;
+    private volatile ByteSizeValue maxWeight;
 
     public Caches(TimeValue expAfterWrite, TimeValue expAfterAccess, ByteSizeValue maxWeight) {
-        this.featureCache = configCache(CacheBuilder.<CacheKey, Feature>builder(), expAfterWrite, expAfterAccess, maxWeight)
+        this.expireAfterWrite = expAfterWrite;
+        this.expireAfterAccess = expAfterAccess;
+        this.maxWeight = maxWeight;
+        initCaches();
+    }
+
+    private void initCaches() {
+        this.featureCache = configCache(CacheBuilder.<CacheKey, Feature>builder(), expireAfterWrite, expireAfterAccess, maxWeight)
             .weigher(Caches::weigther)
             .removalListener((l) -> this.onRemove(l.getKey(), l.getValue()))
             .build();
-        this.featureSetCache = configCache(CacheBuilder.<CacheKey, FeatureSet>builder(), expAfterWrite, expAfterAccess, maxWeight)
+        this.featureSetCache = configCache(CacheBuilder.<CacheKey, FeatureSet>builder(), expireAfterWrite, expireAfterAccess, maxWeight)
             .weigher(Caches::weigther)
             .removalListener((l) -> this.onRemove(l.getKey(), l.getValue()))
             .build();
-        this.modelCache = configCache(CacheBuilder.<CacheKey, CompiledLtrModel>builder(), expAfterWrite, expAfterAccess, maxWeight)
+        this.modelCache = configCache(CacheBuilder.<CacheKey, CompiledLtrModel>builder(), expireAfterWrite, expireAfterAccess, maxWeight)
             .weigher((s, w) -> w.ramBytesUsed())
             .removalListener((l) -> this.onRemove(l.getKey(), l.getValue()))
             .build();
-        this.maxWeight = maxWeight.getBytes();
+    }
+
+    public synchronized void setMaxMem(ByteSizeValue maxMem) {
+        this.maxWeight = maxMem;
+        rebuild();
+    }
+
+    public synchronized void setExpireAfterWrite(TimeValue expireAfterWrite) {
+        this.expireAfterWrite = expireAfterWrite;
+        rebuild();
+    }
+
+    public synchronized void setExpireAfterAccess(TimeValue expireAfterAccess) {
+        this.expireAfterAccess = expireAfterAccess;
+        rebuild();
+    }
+
+    private void rebuild() {
+        logger
+            .info(
+                "Rebuilding LTR caches with max_mem=[{}], expire_after_write=[{}], expire_after_read=[{}]",
+                maxWeight,
+                expireAfterWrite,
+                expireAfterAccess
+            );
+        perStoreStats.clear();
+        initCaches();
     }
 
     public static long weigther(CacheKey key, Object data) {
@@ -116,11 +168,7 @@ public class Caches {
     }
 
     private void onRemove(CacheKey k, Object acc) {
-        perStoreStats.compute(k.getStoreName(), (k2, v) -> {
-            assert v != null;
-            // return null should remove the entry
-            return v.remove(acc) > 0 ? v : null;
-        });
+        perStoreStats.computeIfPresent(k.getStoreName(), (k2, v) -> v.remove(acc) > 0 ? v : null);
     }
 
     Feature loadFeature(CacheKey key, CheckedFunction<String, Feature, IOException> loader) throws IOException {
@@ -205,7 +253,7 @@ public class Caches {
     }
 
     public long getMaxWeight() {
-        return maxWeight;
+        return maxWeight.getBytes();
     }
 
     public static class CacheKey {


### PR DESCRIPTION
### Description

Allows LTR cache settings (`ltr.caches.expire_after_write`, `ltr.caches.expire_after_read`, `ltr.caches.max_mem`) to be configured dynamically via `/_cluster/settings` API.  Note that if/when any cache settings are changed, the cache is rebuilt and cache statistics are reset to zero.

Before, it was not possible to update LTR cache settings via `/_cluster/settings` API since these settings were static:

```
PUT /_cluster/settings
{
  "persistent": {
    "ltr.caches.max_mem": "20mb"
  }
}

{
  "error": {
    "root_cause": [
      {
        "type": "settings_exception",
        "reason": "persistent setting [ltr.caches.max_mem], not dynamically updateable"
      }
    ],
    "type": "settings_exception",
    "reason": "persistent setting [ltr.caches.max_mem], not dynamically updateable"
  },
  "status": 400
}
```

After this change:
```
{
  "acknowledged": true,
  "persistent": {
    "ltr": {
      "caches": {
        "max_mem": "20mb"
      }
    }
  },
  "transient": {}
}
```

And we can see that the plugin settings are updated:
```
GET /_cluster/settings?pretty&include_defaults=true&filter_path=**.ltr.caches*

{
  "persistent" : {
    "ltr" : {
      "caches" : {
        "max_mem" : "20mb"
      }
    }
  },
  "defaults" : {
    "ltr" : {
      "caches" : {
        "expire_after_write" : "1h",
        "expire_after_read" : "1h"
      }
    }
  }
}
```

## Confirm Dynamic Cache Size Change via Eviction

Use `/_cluster/settings` API to change LTR cache max size, then confirm new setting is enforced by caching 2 different test models which together exceed cache max size.

Start with default settings:
```
GET /_cluster/settings?pretty&include_defaults=true&filter_path=**.ltr.caches*

{
  "defaults" : {
    "ltr" : {
      "caches" : {
        "expire_after_write" : "1h",
        "expire_after_read" : "1h",
        "max_mem" : "10mb"
      }
    }
  }
}
```

Change max cache size to 1kb:
```
PUT /_cluster/settings
{
  "persistent": {
    "ltr.caches.max_mem": "1kb"
  }
}
```

Create and populate test index:
```
PUT /test-index
{
  "mappings": {
    "properties": {
      "title": { "type": "text" },
      "description": { "type": "text" }
    }
  }
}

POST /test-index/_doc/1
{
  "title": "opensearch learning to rank",
  "description": "a plugin for relevance tuning"
}

POST /test-index/_refresh
```

Create and populate `_ltr` store:
```
PUT /_ltr

PUT /_ltr/_featureset/test_featureset
{
  "featureset": {
    "name": "test_featureset",
    "features": [
      {
        "name": "title_match",
        "params": ["keywords"],
        "template_language": "mustache",
        "template": { "match": { "title": "{{keywords}}" } }
      },
      {
        "name": "desc_match",
        "params": ["keywords"],
        "template_language": "mustache",
        "template": { "match": { "description": "{{keywords}}" } }
      }
    ]
  }
}

POST /_ltr/_featureset/test_featureset/_createmodel
{
  "model": {
    "name": "modelA",
    "model": {
      "type": "model/linear",
      "definition": "{\"title_match\": 1.0, \"desc_match\": 0.5}"
    }
  }
}

POST /_ltr/_featureset/test_featureset/_createmodel
{
  "model": {
    "name": "modelB",
    "model": {
      "type": "model/linear",
      "definition": "{\"title_match\": 1.0, \"desc_match\": 0.5}"
    }
  }
}
```

Check that LTR cache is empty:
```
GET /_plugins/_ltr/stats?pretty

{
  "_nodes" : {
    "total" : 1,
    "successful" : 1,
    "failed" : 0
  },
  "cluster_name" : "integTest",
  "stores" : {
    ".ltrstore" : {
      "model_count" : 2,
      "featureset_count" : 1,
      "feature_count" : 2,
      "status" : "green"
    }
  },
  "status" : "green",
  "nodes" : {
    "uN3TvQRrTiaBaFWOgM3oUg" : {
      "cache" : {
        "feature" : {
          "eviction_count" : 0,
          "miss_count" : 0,
          "entry_count" : 0,
          "memory_usage_in_bytes" : 0,
          "hit_count" : 0
        },
        "featureset" : {
          "eviction_count" : 0,
          "miss_count" : 0,
          "entry_count" : 0,
          "memory_usage_in_bytes" : 0,
          "hit_count" : 0
        },
        "model" : {
          "eviction_count" : 0,
          "miss_count" : 0,
          "entry_count" : 0,
          "memory_usage_in_bytes" : 0,
          "hit_count" : 0
        }
      },
      "request_total_count" : 0,
      "request_error_count" : 0
    }
  }
}
```

Execute a query against test index
```
GET /test-index/_search
{
  "query": {
    "sltr": {
      "params": { "keywords": "opensearch" },
      "model": "modelA"
    }
  }
}
```

See that 1 model (modelA) is now cached:

```
GET /_plugins/_ltr/stats?pretty

{
  "_nodes" : {
    "total" : 1,
    "successful" : 1,
    "failed" : 0
  },
  "cluster_name" : "integTest",
  "stores" : {
    ".ltrstore" : {
      "model_count" : 2,
      "featureset_count" : 1,
      "feature_count" : 2,
      "status" : "green"
    }
  },
  "status" : "green",
  "nodes" : {
    "uN3TvQRrTiaBaFWOgM3oUg" : {
      "cache" : {
        "feature" : {
          "eviction_count" : 0,
          "miss_count" : 0,
          "entry_count" : 0,
          "memory_usage_in_bytes" : 0,
          "hit_count" : 0
        },
        "featureset" : {
          "eviction_count" : 0,
          "miss_count" : 0,
          "entry_count" : 0,
          "memory_usage_in_bytes" : 0,
          "hit_count" : 0
        },
        "model" : {
          "eviction_count" : 0,
          "miss_count" : 1,
          "entry_count" : 1,
          "memory_usage_in_bytes" : 766,
          "hit_count" : 0
        }
      },
      "request_total_count" : 1,
      "request_error_count" : 0
    }
  }
}
```

Now search again, but with modelB:
```
GET /test-index/_search
{
  "query": {
    "sltr": {
      "params": { "keywords": "opensearch" },
      "model": "modelB"
    }
  }
}
```

See that cache still holds only 1 model, and that second search caused eviction of first cache entry:
```
GET /_plugins/_ltr/stats?pretty

{
  "_nodes" : {
    "total" : 1,
    "successful" : 1,
    "failed" : 0
  },
  "cluster_name" : "integTest",
  "stores" : {
    ".ltrstore" : {
      "model_count" : 2,
      "featureset_count" : 1,
      "feature_count" : 2,
      "status" : "green"
    }
  },
  "status" : "green",
  "nodes" : {
    "uN3TvQRrTiaBaFWOgM3oUg" : {
      "cache" : {
        "feature" : {
          "eviction_count" : 0,
          "miss_count" : 0,
          "entry_count" : 0,
          "memory_usage_in_bytes" : 0,
          "hit_count" : 0
        },
        "featureset" : {
          "eviction_count" : 0,
          "miss_count" : 0,
          "entry_count" : 0,
          "memory_usage_in_bytes" : 0,
          "hit_count" : 0
        },
        "model" : {
          "eviction_count" : 1,
          "miss_count" : 2,
          "entry_count" : 1,
          "memory_usage_in_bytes" : 766,
          "hit_count" : 0
        }
      },
      "request_total_count" : 2,
      "request_error_count" : 0
    }
  }
}
```

### Test Dynamic Cache Rebuild

Following from above steps, change cache size back to 10mb:

```
PUT /_cluster/settings
{
  "persistent": {
    "ltr.caches.max_mem": "10mb"
  }
}
```

See that LTR cache stats have reset:
```
GET /_plugins/_ltr/stats?pretty

{
  "_nodes" : {
    "total" : 1,
    "successful" : 1,
    "failed" : 0
  },
  "cluster_name" : "integTest",
  "stores" : {
    ".ltrstore" : {
      "model_count" : 2,
      "featureset_count" : 1,
      "feature_count" : 2,
      "status" : "green"
    }
  },
  "status" : "green",
  "nodes" : {
    "uN3TvQRrTiaBaFWOgM3oUg" : {
      "cache" : {
        "feature" : {
          "eviction_count" : 0,
          "miss_count" : 0,
          "entry_count" : 0,
          "memory_usage_in_bytes" : 0,
          "hit_count" : 0
        },
        "featureset" : {
          "eviction_count" : 0,
          "miss_count" : 0,
          "entry_count" : 0,
          "memory_usage_in_bytes" : 0,
          "hit_count" : 0
        },
        "model" : {
          "eviction_count" : 0,
          "miss_count" : 0,
          "entry_count" : 0,
          "memory_usage_in_bytes" : 0,
          "hit_count" : 0
        }
      },
      "request_total_count" : 2,
      "request_error_count" : 0
    }
  }
}
```

### Issues Resolved
- https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/314

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
