### PR TITLE
[3.6] Fix CVE-2026-34478

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,9 @@ configurations.configureEach {
   resolutionStrategy.force 'org.eclipse.platform:org.eclipse.core.runtime:3.29.0'
   resolutionStrategy.force 'org.slf4j:slf4j-api:2.0.17'
   resolutionStrategy.force 'com.google.errorprone:error_prone_annotations:2.41.0'
+  resolutionStrategy.force 'org.apache.logging.log4j:log4j-core:2.25.4'
+  resolutionStrategy.force 'org.apache.logging.log4j:log4j-api:2.25.4'
+  resolutionStrategy.force 'org.apache.logging.log4j:log4j-jul:2.25.4'
 }
 
 configurations {


### PR DESCRIPTION
### Description
Fix CVE-2026-34478

Confirmed by:
```
% ./gradlew dependencies | grep -i log4j
|    |    \--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-jul:2.25.3 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.3 -> 2.25.4
+--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4
+--- org.apache.logging.log4j:log4j-core:2.25.3 -> 2.25.4
+--- org.apache.logging.log4j:log4j-api:2.25.3 (n)
+--- org.apache.logging.log4j:log4j-core:2.25.3 (n)
|    |    |    \--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4
|    |    +--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4 (*)
|    |    +--- org.apache.logging.log4j:log4j-jul:2.25.3 -> 2.25.4
|    |    +--- org.apache.logging.log4j:log4j-core:2.25.3 -> 2.25.4
|    |    |    +--- org.apache.logging.log4j:log4j-api:2.25.4 (*)
\--- org.apache.logging.log4j:log4j-core:2.25.3 -> 2.25.4 (*)
\--- org.apache.logging.log4j:log4j-core:2.25.3 (n)
|    |    |    \--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4
|    |    +--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4
|    |    +--- org.apache.logging.log4j:log4j-jul:2.25.3 -> 2.25.4
|    |    +--- org.apache.logging.log4j:log4j-core:2.25.3 -> 2.25.4
|    |    |    \--- org.apache.logging.log4j:log4j-api:2.25.4
\--- org.apache.logging.log4j:log4j-core:2.25.3 -> 2.25.4 (*)
|    |    \--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-jul:2.25.3 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.3 -> 2.25.4
+--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4
+--- org.apache.logging.log4j:log4j-core:2.25.3 -> 2.25.4
|    |    \--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-jul:2.25.3 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.3 -> 2.25.4
+--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4
+--- org.apache.logging.log4j:log4j-core:2.25.3 -> 2.25.4
|    |    \--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-jul:2.25.3 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.25.3 -> 2.25.4
+--- org.apache.logging.log4j:log4j-api:2.25.3 -> 2.25.4
+--- org.apache.logging.log4j:log4j-core:2.25.3 -> 2.25.4
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
