### PR TITLE
Update GitHub username for Rithin Pullela

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gsingers @macohen @sstults @JohannesDaniel @ylwu-amzn @jngz-es @rithin-pullela-aws
+* @gsingers @macohen @sstults @JohannesDaniel @ylwu-amzn @jngz-es @rithinpullela

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,7 +16,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Johannes Peter  | [JohannesDaniel](https://github.com/JohannesDaniel) | Principal Engineer     |
 | Yaliang Wu      | [ylwu-amzn](https://github.com/ylwu-amzn)           | Amazon                 |
 | Jing Zhang      | [jngz-es](https://github.com/jngz-es)               | Amazon                 |
-| Rithin Pullela  | [rithin-pullela-aws](https://github.com/rithin-pullela-aws) | Amazon                 |
+| Rithin Pullela  | [rithinpullela](https://github.com/rithinpullela) | Amazon                 |
 
 ## Emeritus
 


### PR DESCRIPTION
## Summary
- Update `@rithin-pullela-aws` to `@rithinpullela` in `.github/CODEOWNERS` and `MAINTAINERS.md` to reflect my new GitHub username.

## Test plan
- [x] CODEOWNERS reference updated
- [x] MAINTAINERS.md table entry updated (name, link text, and URL)
- [x] No other references to the old username remain