### PR TITLE
[3.0] Backport Spotless P2 mirror timeout Fix & Fix CVE-2026-34478

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -255,7 +255,7 @@ spotless {
     removeUnusedImports()
     importOrder 'java', 'javax', 'org', 'com'
 
-    eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('.eclipseformat.xml')
+    eclipse().configFile rootProject.file('.eclipseformat.xml')
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,9 @@ dependencies {
 configurations.all {
   resolutionStrategy.force "com.google.guava:guava:32.1.3-jre"
   resolutionStrategy.force 'org.eclipse.platform:org.eclipse.core.runtime:3.29.0'
+  resolutionStrategy.force 'org.apache.logging.log4j:log4j-core:2.25.4'
+  resolutionStrategy.force 'org.apache.logging.log4j:log4j-api:2.25.4'
+  resolutionStrategy.force 'org.apache.logging.log4j:log4j-jul:2.25.4'
 }
 
 // see https://github.com/opensearch-project/OpenSearch/blob/0ba0e7cc26060f964fcbf6ee45bae53b3a9941d0/buildSrc/src/main/java/org/opensearch/gradle/precommit/DependencyLicensesTask.java


### PR DESCRIPTION
### Description
- Backport https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/303
- Fix CVE-2026-34478

Confirmed by:
```
% ./gradlew dependencies | grep -i log4j
|    |    \--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-jul:2.21.0 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.21.0 -> 2.25.4
+--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4
+--- org.apache.logging.log4j:log4j-core:2.21.0 -> 2.25.4
+--- org.apache.logging.log4j:log4j-api:2.21.0 (n)
+--- org.apache.logging.log4j:log4j-core:2.21.0 (n)
|    |    |    \--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4
|    |    +--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4 (*)
|    |    +--- org.apache.logging.log4j:log4j-jul:2.21.0 -> 2.25.4
|    |    +--- org.apache.logging.log4j:log4j-core:2.21.0 -> 2.25.4
|    |    |    +--- org.apache.logging.log4j:log4j-api:2.25.4 (*)
\--- org.apache.logging.log4j:log4j-core:2.21.0 -> 2.25.4 (*)
\--- org.apache.logging.log4j:log4j-core:2.21.0 (n)
|    |    |    \--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4
|    |    +--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4
|    |    +--- org.apache.logging.log4j:log4j-jul:2.21.0 -> 2.25.4
|    |    +--- org.apache.logging.log4j:log4j-core:2.21.0 -> 2.25.4
|    |    |    \--- org.apache.logging.log4j:log4j-api:2.25.4
\--- org.apache.logging.log4j:log4j-core:2.21.0 -> 2.25.4 (*)
|    |    \--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-jul:2.21.0 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.21.0 -> 2.25.4
+--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4
+--- org.apache.logging.log4j:log4j-core:2.21.0 -> 2.25.4
\--- org.apache.logging.log4j:log4j-core:2.21.0 -> 2.25.4
\--- org.apache.logging.log4j:log4j-core:2.21.0 (n)
|    |    \--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-jul:2.21.0 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.21.0 -> 2.25.4
+--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4
+--- org.apache.logging.log4j:log4j-core:2.21.0 -> 2.25.4
|    |    \--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-jul:2.21.0 -> 2.25.4
|    +--- org.apache.logging.log4j:log4j-core:2.21.0 -> 2.25.4
+--- org.apache.logging.log4j:log4j-api:2.21.0 -> 2.25.4
+--- org.apache.logging.log4j:log4j-core:2.21.0 -> 2.25.4
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
