### PR TITLE
Fix build.gradle default opensearch_version for 3.0 branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,10 +22,10 @@ jobs:
         java: [21, 23]
     steps:
       - name: Checkout LTR
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # Spotless requires JDK 17+
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -53,13 +53,13 @@ jobs:
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
 
       - name: Checkout LTR Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build and Run Tests
         run: |
@@ -78,12 +78,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
       - name: Checkout LTR Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build and Run Tests
         shell: bash
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
   ext {
-    opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
+    opensearch_version = System.getProperty("opensearch.version", "3.0.0")
     is_snapshot = "true" == System.getProperty("build.snapshot", "true")
     build_version_qualifier = System.getProperty("build.version_qualifier", "")
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 buildscript {
   ext {
     opensearch_version = System.getProperty("opensearch.version", "3.0.0")
-    is_snapshot = "true" == System.getProperty("build.snapshot", "true")
+    is_snapshot = "true" == System.getProperty("build.snapshot", "false")
     build_version_qualifier = System.getProperty("build.version_qualifier", "")
 
     version_tokens = opensearch_version.tokenize('-')

--- a/build.gradle
+++ b/build.gradle
@@ -255,7 +255,7 @@ spotless {
     removeUnusedImports()
     importOrder 'java', 'javax', 'org', 'com'
 
-    eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('.eclipseformat.xml')
+    eclipse().configFile rootProject.file('.eclipseformat.xml')
   }
 }
 


### PR DESCRIPTION
### Description

The `3.0` maintenance branch references `3.0.0-SNAPSHOT` as the default `opensearch_version` in `build.gradle`. Since OpenSearch 3.0.0 has been released, the SNAPSHOT artifact no longer exists in any Maven repository, causing GitHub Actions CI to fail at Gradle configuration time with:

```
Could not find org.opensearch.gradle:build-tools:3.0.0-SNAPSHOT.
```

This is a process gap: when a version is released the Jenkins build pipeline overrides `opensearch.version` explicitly, so release builds were never affected. But GitHub Actions CI uses the default, which is now stale.

### Fix

Change the default from `3.0.0-SNAPSHOT` to the released `3.0.0`.

### Issues Resolved

Unblocks all open PRs targeting the `3.0` branch (including #349).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).