### PR TITLE
[Backport 2.19] Consolidated: Actions pin + maven2 mirror + float/cache/logging fixes + RankyMcRankface 0.3.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,8 +6,7 @@ on:
       - 'backport/**'
       - 'create-pull-request/**'
       - 'dependabot/**'
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  pull_request:
 
 permissions:
   id-token: write

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,16 +22,20 @@ jobs:
   spotless:
     if: github.repository == 'opensearch-project/opensearch-learning-to-rank-base'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [21]
     steps:
       - name: Checkout LTR
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       # Spotless requires JDK 17+
       - name: Setup Java 21
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
-          java-version: 21
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
       - name: Spotless Check
         run: ./gradlew spotlessCheck
 
@@ -56,13 +60,13 @@ jobs:
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
 
       - name: Checkout LTR Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -83,12 +87,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
       - name: Checkout LTR Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Build and Run Tests

--- a/.github/workflows/add-untriaged-label.yml
+++ b/.github/workflows/add-untriaged-label.yml
@@ -4,11 +4,14 @@ on:
   issues:
     types: [opened, reopened, transferred]
 
+permissions:
+  issues: write
+
 jobs:
   apply-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             github.rest.issues.addLabels({

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
   }
@@ -115,6 +116,7 @@ publishing {
 repositories {
   mavenLocal()
   maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+  maven { url "https://ci.opensearch.org/maven2/" }
   mavenCentral()
   maven { url "https://plugins.gradle.org/m2/" }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ dependencies {
   implementation "org.ow2.asm:asm:${ow2Version}"
   implementation "org.ow2.asm:asm-commons:${ow2Version}"
   implementation "org.ow2.asm:asm-tree:${ow2Version}"
-  implementation 'com.o19s:RankyMcRankFace:0.1.1'
+  implementation 'com.o19s:RankyMcRankFace:0.3.0'
   implementation "com.github.spullara.mustache.java:compiler:0.9.3"
   implementation "org.conscrypt:conscrypt-openjdk-uber:2.5.2"
   implementation 'org.slf4j:slf4j-api:1.7.36'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,10 @@
+pluginManagement {
+    repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'opensearch-ltr'
 include ':rest-api-spec'

--- a/src/javaRestTest/java/com/o19s/es/ltr/NodeSettingsIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/NodeSettingsIT.java
@@ -67,7 +67,7 @@ public class NodeSettingsIT extends BaseIntegrationTest {
             cached.loadModel(compiled.name());
             caches.modelCache().refresh();
             assertThat(caches.modelCache().weight(), allOf(lessThan(maxMemSize), greaterThanOrEqualTo(lastAddedSize)));
-        } while (totalAdded < maxMemSize);
+        } while (totalAdded <= maxMemSize);
         assertThat(totalAdded, greaterThan(maxMemSize));
         assertThat(caches.modelCache().weight(), greaterThan(0L));
         Thread.sleep(expireAfterWrite * 2);

--- a/src/main/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilder.java
@@ -76,7 +76,7 @@ public class LoggingSearchExtBuilder extends SearchExtBuilder {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
+        builder.startObject(NAME);
         builder.field(LOG_SPECS.getPreferredName(), logSpecs);
         return builder.endObject();
     }

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilderTests.java
@@ -65,12 +65,14 @@ public class LoggingSearchExtBuilderTests extends OpenSearchTestCase {
         assertTestExt(ext);
     }
 
-    public void testToXCtontent() throws IOException {
+    public void testToXContent() throws IOException {
         LoggingSearchExtBuilder ext1 = buildTestExt();
         XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
         ext1.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
         builder.close();
-        assertEquals(getTestExtAsString(), builder.toString());
+        assertEquals("{\"ltr_log\":" + getTestExtAsString() + "}", builder.toString());
     }
 
     public void testSer() throws IOException {
@@ -79,6 +81,39 @@ public class LoggingSearchExtBuilderTests extends OpenSearchTestCase {
         out.close();
         LoggingSearchExtBuilder ext = new LoggingSearchExtBuilder(out.bytes().streamInput());
         assertTestExt(ext);
+    }
+
+    /**
+     * Simulates the SearchSourceBuilder round-trip: serialize the ext section
+     * with toXContent (as SearchSourceBuilder.innerToXContent does), then parse
+     * it back and verify the result matches the original.
+     * This is the code path that failed before the fix when a search pipeline
+     * triggered re-serialization of the search request.
+     */
+    public void testToXContentRoundTrip() throws IOException {
+        LoggingSearchExtBuilder original = buildTestExt();
+
+        // Serialize: simulate SearchSourceBuilder writing the "ext" object
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject("ext");
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        builder.endObject();
+        builder.close();
+
+        // Parse: simulate SearchSourceBuilder parsing the "ext" section
+        XContentParser parser = createParser(JsonXContent.jsonXContent, builder.toString());
+        parser.nextToken(); // START_OBJECT (root)
+        parser.nextToken(); // FIELD_NAME "ext"
+        parser.nextToken(); // START_OBJECT (ext)
+        parser.nextToken(); // FIELD_NAME "ltr_log"
+        assertEquals(LoggingSearchExtBuilder.NAME, parser.currentName());
+        parser.nextToken(); // START_OBJECT (ltr_log value)
+
+        LoggingSearchExtBuilder parsed = parse(parser);
+        assertTestExt(parsed);
+        assertEquals(original, parsed);
     }
 
     public void testFailOnNoLogSpecs() throws IOException {

--- a/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
@@ -105,7 +105,7 @@ import ciir.umass.edu.utilities.MyThreadPool;
 @LuceneTestCase.SuppressSysoutChecks(bugUrl = "RankURL does this when training models... ")
 public class LtrQueryTests extends LuceneTestCase {
     // Number of ULPs allowed when checking scores equality
-    private static final int SCORE_NB_ULP_PREC = 1;
+    private static final int SCORE_NB_ULP_PREC = 30000;
 
     private int[] range(int start, int stop) {
         int[] result = new int[stop - start];


### PR DESCRIPTION
Consolidated backport to the `2.19` branch (rebase-and-merge friendly — please do NOT squash; separate commits preserved, each cherry-picked with `-x`).

### Includes
- Pin GitHub Actions to commit SHAs (#334) — **required** for CI (SHA-pin ruleset); manually adapted to 2.19's `[11,17,21]` Java matrix and the legacy `setup-java@v1` spotless step.
- Add ci.opensearch.org maven2 mirror to avoid Maven Central throttling (#338) — manually adapted to 2.19's `settings.gradle` (pluginManagement) and both `build.gradle` repositories blocks.
- Float-comparison de-flake: ULP precision (#205) + hybrid comparison (#221).
- Bug/cache size IT fix (#248).
- Fix rescore-only feature SLTR logging (#266).
- Fix LoggingSearchExtBuilder.toXContent missing field name (#290).
- Add `issues: write` to untriaged-label workflow (#323).
- Upgrade RankyMcRankFace 0.1.1 → 0.3.0 (#354) — fixes XXE/DTD vulnerability.

### Not included
2.19 already has log4j forced to 2.25.4 (CVE-2026-34478 covered) and has no `withP2Mirrors()` workaround, so the CVE/P2 commits do not apply. 3.x-line-only changes (Lucene 10, JDK-21-only, system-indices onboarding) are excluded as incompatible with the 2.x line.

### Verified
`./gradlew clean spotlessCheck compileJava compileTestJava test` passes locally on JDK 21 (277 tests, 0 failures).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
