### PR TITLE
[Backport 3.1] Consolidated: version-default + Actions pin + P2 + CVE-2026-34478 + float/ML/logging fixes + RankyMcRankface 0.3.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,10 +22,10 @@ jobs:
         java: [21, 23]
     steps:
       - name: Checkout LTR
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # Spotless requires JDK 17+
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -53,13 +53,13 @@ jobs:
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
 
       - name: Checkout LTR Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build and Run Tests
         run: |
@@ -78,12 +78,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
       - name: Checkout LTR Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build and Run Tests
         shell: bash
         run: |

--- a/.github/workflows/add-untriaged-label.yml
+++ b/.github/workflows/add-untriaged-label.yml
@@ -4,11 +4,14 @@ on:
   issues:
     types: [opened, reopened, transferred]
 
+permissions:
+  issues: write
+
 jobs:
   apply-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             github.rest.issues.addLabels({

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 buildscript {
   ext {
     opensearch_version = System.getProperty("opensearch.version", "3.1.0")
-    is_snapshot = "true" == System.getProperty("build.snapshot", "true")
+    is_snapshot = "true" == System.getProperty("build.snapshot", "false")
     build_version_qualifier = System.getProperty("build.version_qualifier", "")
 
     version_tokens = opensearch_version.tokenize('-')

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
   ext {
-    opensearch_version = System.getProperty("opensearch.version", "3.1.0-SNAPSHOT")
+    opensearch_version = System.getProperty("opensearch.version", "3.1.0")
     is_snapshot = "true" == System.getProperty("build.snapshot", "true")
     build_version_qualifier = System.getProperty("build.version_qualifier", "")
 

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ dependencies {
   implementation "org.ow2.asm:asm:${ow2Version}"
   implementation "org.ow2.asm:asm-commons:${ow2Version}"
   implementation "org.ow2.asm:asm-tree:${ow2Version}"
-  implementation 'com.o19s:RankyMcRankFace:0.1.1'
+  implementation 'com.o19s:RankyMcRankFace:0.3.0'
   implementation "com.github.spullara.mustache.java:compiler:0.9.3"
   implementation "org.conscrypt:conscrypt-openjdk-uber:2.5.2"
   implementation 'org.slf4j:slf4j-api:1.7.36'

--- a/build.gradle
+++ b/build.gradle
@@ -255,7 +255,7 @@ spotless {
     removeUnusedImports()
     importOrder 'java', 'javax', 'org', 'com'
 
-    eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('.eclipseformat.xml')
+    eclipse().configFile rootProject.file('.eclipseformat.xml')
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,9 @@ dependencies {
 configurations.all {
   resolutionStrategy.force "com.google.guava:guava:32.1.3-jre"
   resolutionStrategy.force 'org.eclipse.platform:org.eclipse.core.runtime:3.29.0'
+  resolutionStrategy.force 'org.apache.logging.log4j:log4j-core:2.25.4'
+  resolutionStrategy.force 'org.apache.logging.log4j:log4j-api:2.25.4'
+  resolutionStrategy.force 'org.apache.logging.log4j:log4j-jul:2.25.4'
 }
 
 // see https://github.com/opensearch-project/OpenSearch/blob/0ba0e7cc26060f964fcbf6ee45bae53b3a9941d0/buildSrc/src/main/java/org/opensearch/gradle/precommit/DependencyLicensesTask.java

--- a/src/main/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilder.java
@@ -76,7 +76,7 @@ public class LoggingSearchExtBuilder extends SearchExtBuilder {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
+        builder.startObject(NAME);
         builder.field(LOG_SPECS.getPreferredName(), logSpecs);
         return builder.endObject();
     }

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilderTests.java
@@ -65,12 +65,14 @@ public class LoggingSearchExtBuilderTests extends OpenSearchTestCase {
         assertTestExt(ext);
     }
 
-    public void testToXCtontent() throws IOException {
+    public void testToXContent() throws IOException {
         LoggingSearchExtBuilder ext1 = buildTestExt();
         XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
         ext1.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
         builder.close();
-        assertEquals(getTestExtAsString(), builder.toString());
+        assertEquals("{\"ltr_log\":" + getTestExtAsString() + "}", builder.toString());
     }
 
     public void testSer() throws IOException {
@@ -79,6 +81,39 @@ public class LoggingSearchExtBuilderTests extends OpenSearchTestCase {
         out.close();
         LoggingSearchExtBuilder ext = new LoggingSearchExtBuilder(out.bytes().streamInput());
         assertTestExt(ext);
+    }
+
+    /**
+     * Simulates the SearchSourceBuilder round-trip: serialize the ext section
+     * with toXContent (as SearchSourceBuilder.innerToXContent does), then parse
+     * it back and verify the result matches the original.
+     * This is the code path that failed before the fix when a search pipeline
+     * triggered re-serialization of the search request.
+     */
+    public void testToXContentRoundTrip() throws IOException {
+        LoggingSearchExtBuilder original = buildTestExt();
+
+        // Serialize: simulate SearchSourceBuilder writing the "ext" object
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject("ext");
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        builder.endObject();
+        builder.close();
+
+        // Parse: simulate SearchSourceBuilder parsing the "ext" section
+        XContentParser parser = createParser(JsonXContent.jsonXContent, builder.toString());
+        parser.nextToken(); // START_OBJECT (root)
+        parser.nextToken(); // FIELD_NAME "ext"
+        parser.nextToken(); // START_OBJECT (ext)
+        parser.nextToken(); // FIELD_NAME "ltr_log"
+        assertEquals(LoggingSearchExtBuilder.NAME, parser.currentName());
+        parser.nextToken(); // START_OBJECT (ltr_log value)
+
+        LoggingSearchExtBuilder parsed = parse(parser);
+        assertTestExt(parsed);
+        assertEquals(original, parsed);
     }
 
     public void testFailOnNoLogSpecs() throws IOException {

--- a/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
+++ b/src/test/java/com/o19s/es/ltr/query/LtrQueryTests.java
@@ -105,7 +105,7 @@ import ciir.umass.edu.utilities.MyThreadPool;
 @LuceneTestCase.SuppressSysoutChecks(bugUrl = "RankURL does this when training models... ")
 public class LtrQueryTests extends LuceneTestCase {
     // Number of ULPs allowed when checking scores equality
-    private static final int SCORE_NB_ULP_PREC = 1;
+    private static final int SCORE_NB_ULP_PREC = 30000;
 
     private int[] range(int start, int stop) {
         int[] result = new int[stop - start];

--- a/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
+++ b/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
@@ -24,11 +24,13 @@ setup:
   - do:
           allowed_warnings:
             - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
+            - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
           ltr.create_store: {}
 
   - do:
         allowed_warnings:
           - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
+          - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
         ltr.create_featureset:
            name: my_featureset
            body:
@@ -49,6 +51,7 @@ setup:
   - do:
         allowed_warnings:
           - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
+          - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
         ltr.add_features_to_set:
            name: my_featureset
            body:
@@ -60,6 +63,7 @@ setup:
   - do:
         allowed_warnings:
           - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
+          - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
         ltr.add_features_to_set:
            name: my_featureset
            body:
@@ -73,6 +77,7 @@ setup:
   - do:
         allowed_warnings:
           - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
+          - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
         ltr.create_model_from_set:
             name: my_featureset
             body:
@@ -107,6 +112,7 @@ setup:
   - do:
         allowed_warnings:
           - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
+          - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
         ltr.create_model_from_set:
             name: my_featureset
             body:
@@ -121,6 +127,7 @@ setup:
   - do:
         allowed_warnings:
           - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
+          - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
         ltr.create_model_from_set:
             name: my_featureset
             body:
@@ -140,6 +147,7 @@ setup:
   - do:
       allowed_warnings:
         - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
+        - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
       search:
         index: test
         body: { query: { "sltr": { "params": {"query_string": "rambo"}, "model": "single_feature_ranklib_model"  } } }
@@ -154,6 +162,7 @@ setup:
   - do:
       allowed_warnings:
         - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
+        - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
       search:
         index: test
         body: { query: { "sltr": { "params": {"query_string": "rambo"}, "model": "single_feature_linear_model"  } } }
@@ -167,6 +176,7 @@ setup:
   - do:
       allowed_warnings:
         - "this request accesses system indices: [.ltrstore], but in a future major version, direct access to system indices will be prevented by default"
+        - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
       search:
         index: test
         body: { query: { "sltr": { "params": {}, "model": "three_feature_linear_model", "active_features": ["no_param_feature"]}  } }

--- a/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
+++ b/src/test/resources/rest-api-spec/test/fstore/80_search_w_partial_models.yml
@@ -19,7 +19,8 @@ setup:
         body:   { "field1": "v1 aoeu", "field2": " ua u v2", "field3": "foo bar text", "user_rating": 0.0  }
 
   - do:
-      indices.refresh: { test }
+      indices.refresh:
+        index: test
 
   - do:
           allowed_warnings:


### PR DESCRIPTION
Consolidated backport to the `3.1` branch (rebase-and-merge friendly — please do NOT squash; separate commits preserved, each cherry-picked with `-x`).

### Includes
- Update default opensearch_version to released 3.1.0 + build.snapshot default + Pin GitHub Actions to SHAs + remove withP2Mirrors() (from the 3.1 build-fix PR; keeps `get-ci-image-tag@main`).
- Fix CVE-2026-34478: force log4j 2.25.4.
- Float-comparison de-flake: ULP precision (#205) + hybrid comparison (#221).
- Allow .plugins-ml-config index warnings (#256) + ml index-warning fix (#269).
- Fix LoggingSearchExtBuilder.toXContent missing field name (#290).
- Add `issues: write` to untriaged-label workflow (#323).
- Upgrade RankyMcRankFace 0.1.1 → 0.3.0 (#354) — fixes XXE/DTD vulnerability.

### Not included (not cleanly applicable to 3.1's older structure)
`#224` (slf4j 2.0.17), `#226` (log4j-bundle exclusion), `#228` (jacoco coverage), `#248`/`#266` (javaRestTest paths absent on 3.1), `#271` (depends on the #259 rework). The log4j CVE is already addressed here via the 2.25.4 force.

### Verified
`./gradlew clean spotlessCheck compileJava compileTestJava test` passes locally on JDK 21 (282 tests, 0 failures).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
