### PR TITLE
[Backport 3.2] Consolidated: version-default + Actions pin + P2 fix + CVE-2026-34478 + RankyMcRankface 0.3.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,10 +22,10 @@ jobs:
         java: [21, 24]
     steps:
       - name: Checkout LTR
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # Spotless requires JDK 17+
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -53,13 +53,13 @@ jobs:
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
 
       - name: Checkout LTR Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build and Run Tests
         run: |
@@ -68,7 +68,7 @@ jobs:
                               ./gradlew -Dtests.security.manager=false clean test -x spotlessJava'
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
         with:
             token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -82,12 +82,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
       - name: Checkout LTR Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build and Run Tests
         shell: bash
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
   ext {
-    opensearch_version = System.getProperty("opensearch.version", "3.2.0-SNAPSHOT")
+    opensearch_version = System.getProperty("opensearch.version", "3.2.0")
     is_snapshot = "true" == System.getProperty("build.snapshot", "true")
     build_version_qualifier = System.getProperty("build.version_qualifier", "")
 

--- a/build.gradle
+++ b/build.gradle
@@ -257,7 +257,7 @@ spotless {
     removeUnusedImports()
     importOrder 'java', 'javax', 'org', 'com'
 
-    eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('.eclipseformat.xml')
+    eclipse().configFile rootProject.file('.eclipseformat.xml')
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,9 @@ dependencies {
 configurations.all {
   resolutionStrategy.force "com.google.guava:guava:32.1.3-jre"
   resolutionStrategy.force 'org.eclipse.platform:org.eclipse.core.runtime:3.29.0'
+  resolutionStrategy.force 'org.apache.logging.log4j:log4j-core:2.25.4'
+  resolutionStrategy.force 'org.apache.logging.log4j:log4j-api:2.25.4'
+  resolutionStrategy.force 'org.apache.logging.log4j:log4j-jul:2.25.4'
 }
 
 // see https://github.com/opensearch-project/OpenSearch/blob/0ba0e7cc26060f964fcbf6ee45bae53b3a9941d0/buildSrc/src/main/java/org/opensearch/gradle/precommit/DependencyLicensesTask.java

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 buildscript {
   ext {
     opensearch_version = System.getProperty("opensearch.version", "3.2.0")
-    is_snapshot = "true" == System.getProperty("build.snapshot", "true")
+    is_snapshot = "true" == System.getProperty("build.snapshot", "false")
     build_version_qualifier = System.getProperty("build.version_qualifier", "")
 
     version_tokens = opensearch_version.tokenize('-')

--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ dependencies {
   implementation "org.ow2.asm:asm:${ow2Version}"
   implementation "org.ow2.asm:asm-commons:${ow2Version}"
   implementation "org.ow2.asm:asm-tree:${ow2Version}"
-  implementation 'com.o19s:RankyMcRankFace:0.1.1'
+  implementation 'com.o19s:RankyMcRankFace:0.3.0'
   implementation "com.github.spullara.mustache.java:compiler:0.9.3"
   implementation "org.conscrypt:conscrypt-openjdk-uber:2.5.2"
   implementation 'org.slf4j:slf4j-api:1.7.36'


### PR DESCRIPTION
Consolidated backport to the `3.2` branch (rebase-and-merge friendly — please do NOT squash; separate commits preserved, each cherry-picked with `-x`).

### Includes
- Update default opensearch_version to released 3.2.0 + build.snapshot default (#353).
- Pin GitHub Actions to commit SHAs (#353) — **required** for CI.
- Fix Spotless P2 mirror timeout by removing withP2Mirrors() (#353).
- Fix CVE-2026-34478: force log4j to 2.25.4 (#347).
- Upgrade RankyMcRankFace 0.1.1 → 0.3.0 (#354) — fixes XXE/DTD vulnerability.

This **supersedes the overlapping** #347 (CVE) and #353 (build-default) for 3.2 — see comments on those PRs. Other fixes (#221/#224/#228/#256/#266/#269/#271/#290) are already present on 3.2.

### Verified
`./gradlew clean spotlessCheck compileJava compileTestJava test` passes locally on JDK 21 (289 tests; one known flaky test `LtrQueryTests.testExplainWithNames` passes on rerun).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
