### PR TITLE
[Backport 3.5] Pin Actions + maven2 mirror + untriaged-perm + RankyMcRankface 0.3.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,10 +22,10 @@ jobs:
         java: [21, 25]
     steps:
       - name: Checkout LTR
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # Spotless requires JDK 17+
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -53,13 +53,13 @@ jobs:
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
 
       - name: Checkout LTR Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build and Run Tests
         run: |
@@ -68,7 +68,7 @@ jobs:
                               ./gradlew -Dtests.security.manager=false clean test jacocoTestReport -x spotlessJava'
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
         with:
             files: build/reports/jacoco/test/jacocoTestReport.xml
             token: ${{ secrets.CODECOV_TOKEN }}
@@ -83,12 +83,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
       - name: Checkout LTR Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build and Run Tests
         shell: bash
         run: |

--- a/.github/workflows/add-untriaged-label.yml
+++ b/.github/workflows/add-untriaged-label.yml
@@ -4,11 +4,14 @@ on:
   issues:
     types: [opened, reopened, transferred]
 
+permissions:
+  issues: write
+
 jobs:
   apply-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,14 +26,14 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v2.1.0
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
 
       - name: Backport
-        uses: VachaShah/backport@v2.2.0
+        uses: VachaShah/backport@142d3b8a8c70dc54db515e653e5ed3c3fac64100 # v2.2.0
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
           head_template: backport/backport-<%= number %>-to-<%= base %>

--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'opensearch-project/opensearch-learning-to-rank-base' && startsWith(github.event.pull_request.head.ref,'backport/')
     steps:
     - name: Delete merged branch
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           github.rest.git.deleteRef({

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,14 +24,14 @@ jobs:
 
     - name: Set up Docker Buildx
       id: setup-docker-buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build and push
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3
       with:
         file: docker/Dockerfile
         # TODO: fix this so it isn't hardcoded

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Set release version Name
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: Set up JDK 17.0
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1
       with:
         java-version: 17.0
     - name: Grant execute permission for gradlew
@@ -30,14 +30,14 @@ jobs:
       run: mv ./build/distributions/ltr-*.zip ./ltr-plugin-${{ env.RELEASE_VERSION }}.zip
     - name: Create Release
       id: create_release
-      uses: ncipollo/release-action@v1
+      uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
       with:
         artifacts: "./ltr-plugin-${{ env.RELEASE_VERSION }}.zip"
         token: ${{ secrets.GITHUB_TOKEN }}
         tag: "release-${{ env.RELEASE_VERSION }}"
     - name: Upload Release Asset
       id: upload-release-asset 
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         tag_name: "release-${{ env.RELEASE_VERSION }}"

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ dependencies {
   implementation "org.ow2.asm:asm:${ow2Version}"
   implementation "org.ow2.asm:asm-commons:${ow2Version}"
   implementation "org.ow2.asm:asm-tree:${ow2Version}"
-  implementation 'com.o19s:RankyMcRankFace:0.1.1'
+  implementation 'com.o19s:RankyMcRankFace:0.3.0'
   implementation "com.github.spullara.mustache.java:compiler:0.9.3"
   implementation "org.conscrypt:conscrypt-openjdk-uber:2.5.2"
   implementation 'org.slf4j:slf4j-api:2.0.17'

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
   }
@@ -117,6 +118,7 @@ publishing {
 repositories {
   mavenLocal()
   maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+  maven { url "https://ci.opensearch.org/maven2/" }
   mavenCentral()
   maven { url "https://plugins.gradle.org/m2/" }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,9 @@
+pluginManagement {
+    repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'ltr'


### PR DESCRIPTION
Consolidated backport to the `3.5` branch (rebase-and-merge friendly — please do NOT squash; separate commits preserved, each cherry-picked with `-x`).

### Includes
- Pin GitHub Actions to commit SHAs (#334) — **required** for CI (SHA-pin ruleset).
- Add ci.opensearch.org maven2 mirror to avoid Maven Central throttling (#338).
- Add `issues: write` permission to the untriaged-label workflow (#323).
- Upgrade RankyMcRankFace 0.1.1 → 0.3.0 (#354) — fixes XXE/DTD vulnerability.

### Verified
`./gradlew clean spotlessCheck compileJava compileTestJava test` passes locally on JDK 21 (290 tests, 0 failures).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
