### PR TITLE
[Backport 3.2] Fix LoggingSearchExtBuilder.toXContent missing field name (rebased)

### DIFF
--- a/src/main/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilder.java
+++ b/src/main/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilder.java
@@ -76,7 +76,7 @@ public class LoggingSearchExtBuilder extends SearchExtBuilder {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
+        builder.startObject(NAME);
         builder.field(LOG_SPECS.getPreferredName(), logSpecs);
         return builder.endObject();
     }

--- a/src/test/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilderTests.java
+++ b/src/test/java/com/o19s/es/ltr/logging/LoggingSearchExtBuilderTests.java
@@ -65,12 +65,14 @@ public class LoggingSearchExtBuilderTests extends OpenSearchTestCase {
         assertTestExt(ext);
     }
 
-    public void testToXCtontent() throws IOException {
+    public void testToXContent() throws IOException {
         LoggingSearchExtBuilder ext1 = buildTestExt();
         XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
         ext1.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
         builder.close();
-        assertEquals(getTestExtAsString(), builder.toString());
+        assertEquals("{\"ltr_log\":" + getTestExtAsString() + "}", builder.toString());
     }
 
     public void testSer() throws IOException {
@@ -79,6 +81,39 @@ public class LoggingSearchExtBuilderTests extends OpenSearchTestCase {
         out.close();
         LoggingSearchExtBuilder ext = new LoggingSearchExtBuilder(out.bytes().streamInput());
         assertTestExt(ext);
+    }
+
+    /**
+     * Simulates the SearchSourceBuilder round-trip: serialize the ext section
+     * with toXContent (as SearchSourceBuilder.innerToXContent does), then parse
+     * it back and verify the result matches the original.
+     * This is the code path that failed before the fix when a search pipeline
+     * triggered re-serialization of the search request.
+     */
+    public void testToXContentRoundTrip() throws IOException {
+        LoggingSearchExtBuilder original = buildTestExt();
+
+        // Serialize: simulate SearchSourceBuilder writing the "ext" object
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject("ext");
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        builder.endObject();
+        builder.close();
+
+        // Parse: simulate SearchSourceBuilder parsing the "ext" section
+        XContentParser parser = createParser(JsonXContent.jsonXContent, builder.toString());
+        parser.nextToken(); // START_OBJECT (root)
+        parser.nextToken(); // FIELD_NAME "ext"
+        parser.nextToken(); // START_OBJECT (ext)
+        parser.nextToken(); // FIELD_NAME "ltr_log"
+        assertEquals(LoggingSearchExtBuilder.NAME, parser.currentName());
+        parser.nextToken(); // START_OBJECT (ltr_log value)
+
+        LoggingSearchExtBuilder parsed = parse(parser);
+        assertTestExt(parsed);
+        assertEquals(original, parsed);
     }
 
     public void testFailOnNoLogSpecs() throws IOException {


### PR DESCRIPTION
Backport of #290 (`LoggingSearchExtBuilder.toXContent` missing field name) to `3.2`, **rebased onto the current `3.2` head** so CI passes.

This replaces #296, whose branch (`backport/backport-290-to-3.2`) was based on an old `3.2` with unpinned GitHub Actions — its build jobs fail the SHA-pinned-actions ruleset at "Set up job". This branch is rebased onto current `3.2` (pinned actions from #358), keeping only the #290 fix commit.

### Contains
- `LoggingSearchExtBuilder.java`: `builder.startObject()` → `builder.startObject(NAME)` so the ext serializes under its named key.
- `LoggingSearchExtBuilderTests.java`: `testToXContent` rename, `{"ltr_log":...}` assertion, and new `testToXContentRoundTrip` test.

Verified locally on JDK 21: BUILD SUCCESSFUL, 290 tests, 0 failures.

Supersedes #296. By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
