### PR TITLE
[AUTO] Increment version to 3.6.1-SNAPSHOT (manual)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
   ext {
-    opensearch_version = System.getProperty("opensearch.version", "3.6.0-SNAPSHOT")
+    opensearch_version = System.getProperty("opensearch.version", "3.6.1-SNAPSHOT")
     is_snapshot = "true" == System.getProperty("build.snapshot", "true")
     build_version_qualifier = System.getProperty("build.version_qualifier", "")
 


### PR DESCRIPTION
Manual replacement for #316 — bumps the default `opensearch_version` to `3.6.1-SNAPSHOT` on the `3.6` branch.

#316 (raised by `opensearch-trigger-bot`) could not be updated/rebased because the repository ruleset blocks force-push to its branch. This is the identical one-line change from my fork so it can be managed directly.

> ⚠️ Note: the build jobs will stay red until OpenSearch core publishes `org.opensearch:common-utils:3.6.1.0-SNAPSHOT` (currently 404). This is an upstream-dependency timing issue, not a code problem — re-run CI once that snapshot is available. Close this if 3.6.1 is not a planned patch release.

Supersedes #316. By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
