### PR TITLE
Fix dependency resolution during snapshot builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,10 @@ buildscript {
 
   repositories {
     mavenLocal()
-    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven {
+      url "https://ci.opensearch.org/ci/dbc/snapshots/maven/"
+      content { includeGroupByRegex "org\\.opensearch.*" }
+    }
     maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
@@ -117,7 +120,10 @@ publishing {
 // OpenSearch dependency is included due to the build-tools, test-framework as well
 repositories {
   mavenLocal()
-  maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+  maven {
+    url "https://ci.opensearch.org/ci/dbc/snapshots/maven/"
+    content { includeGroupByRegex "org\\.opensearch.*" }
+  }
   maven { url "https://ci.opensearch.org/maven2/" }
   mavenCentral()
   maven { url "https://plugins.gradle.org/m2/" }


### PR DESCRIPTION
### Description
During CI builds we are encountering the following error:

> * What went wrong:
A problem occurred configuring root project 'opensearch-ltr'.
> Could not resolve all files for configuration ':classpath'.
   > Could not resolve com.perforce:p4java:2015.2.1365273.
     Required by:
         project : > org.opensearch.gradle:build-tools:2.19.6 > com.netflix.nebula:gradle-info-plugin:12.1.6
      > Could not resolve com.perforce:p4java:2015.2.1365273.
         > Could not get resource 'https://ci.opensearch.org/ci/dbc/snapshots/maven/com/perforce/p4java/2015.2.1365273/p4java-2015.2.1365273.pom'.
            > Could not HEAD 'https://ci.opensearch.org/ci/dbc/snapshots/maven/com/perforce/p4java/2015.2.1365273/p4java-2015.2.1365273.pom'. Received status code 503 from server: Service Unavailable

This is because when we are building a snapshot, _all_ dependencies are being looked up in the snapshot repo. Instead we should only be looking for OpenSearch packages there and leave the other dependencies to be found in the regular repo.

This PR adds a package inclusion regex for things that should be found in the snapshot repo, leaving the others to be found in the next repo by priority.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
