### PR TITLE
Honor XGBoost per-node missing/default_left direction at scoring time

### DIFF
--- a/src/javaRestTest/java/com/o19s/es/ltr/query/StoredLtrQueryIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/query/StoredLtrQueryIT.java
@@ -416,7 +416,29 @@ public class StoredLtrQueryIT extends BaseIntegrationTest {
         + "   {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
         + "]}]";
 
+    private static final String SIMPLE_MODEL_XGB_MISSING_YES = "[{"
+        + "\"nodeid\": 0,"
+        + "\"split\":\"text_feature1\","
+        + "\"depth\":0,"
+        + "\"split_condition\":100.0,"
+        + "\"yes\":1,"
+        + "\"no\":2,"
+        + "\"missing\":1,"
+        + "\"children\": ["
+        + "   {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5},"
+        + "   {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
+        + "]}]";
+
     public void testScriptFeatureUseCaseMissingFeatureNaiveAdditiveDecisionTree() throws Exception {
+        assertMissingFeatureScore(SIMPLE_MODEL_XGB, 0.2F);
+    }
+
+    public void testScriptFeatureUseCaseMissingFeatureRoutedByMissingDirection() throws Exception {
+        // "missing":1 -> a missing feature must take the "yes" child (leaf 0.5), not the "no" child.
+        assertMissingFeatureScore(SIMPLE_MODEL_XGB_MISSING_YES, 0.5F);
+    }
+
+    private void assertMissingFeatureScore(String xgbModel, float expectedScore) throws Exception {
         List<StoredFeature> features = new ArrayList<>(1);
         features
             .add(
@@ -433,7 +455,7 @@ public class StoredLtrQueryIT extends BaseIntegrationTest {
         StoredLtrModel model = new StoredLtrModel(
             "my_model",
             set,
-            new StoredLtrModel.LtrModelDefinition("model/xgboost+json", SIMPLE_MODEL_XGB, true)
+            new StoredLtrModel.LtrModelDefinition("model/xgboost+json", xgbModel, true)
         );
         addElement(model);
 
@@ -471,7 +493,7 @@ public class StoredLtrQueryIT extends BaseIntegrationTest {
         assertEquals("text_feature1", log.get(0).get("name"));
         assertEquals(null, log.get(0).get("value"));
 
-        assertEquals(0.2F, hit.getScore(), Math.ulp(0.2F));
+        assertEquals(expectedScore, hit.getScore(), Math.ulp(expectedScore));
     }
 
 }

--- a/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
@@ -95,12 +95,27 @@ public class NaiveAdditiveDecisionTree extends SparseLtrRanker implements Accoun
         private final Node right;
         private final int feature;
         private final float threshold;
+        private final boolean defaultLeft;
 
+        /**
+         * Backward-compatible constructor. A missing (NaN) feature value is routed to the
+         * right child, matching the behavior before per-node missing directions were honored.
+         */
         public Split(Node left, Node right, int feature, float threshold) {
+            this(left, right, feature, threshold, false);
+        }
+
+        /**
+         * @param defaultLeft when true a missing (NaN) feature value is routed to the left (yes)
+         *                    child, otherwise to the right (no) child. This mirrors XGBoost's
+         *                    per-node missing direction (the "missing" pointer / "default_left" flag).
+         */
+        public Split(Node left, Node right, int feature, float threshold, boolean defaultLeft) {
             this.left = Objects.requireNonNull(left);
             this.right = Objects.requireNonNull(right);
             this.feature = feature;
             this.threshold = threshold;
+            this.defaultLeft = defaultLeft;
         }
 
         @Override
@@ -114,7 +129,10 @@ public class NaiveAdditiveDecisionTree extends SparseLtrRanker implements Accoun
             while (!n.isLeaf()) {
                 assert n instanceof Split;
                 Split s = (Split) n;
-                if (s.threshold > scores[s.feature]) {
+                float value = scores[s.feature];
+                if (Float.isNaN(value)) {
+                    n = s.defaultLeft ? s.left : s.right;
+                } else if (s.threshold > value) {
                     n = s.left;
                 } else {
                     n = s.right;
@@ -138,6 +156,10 @@ public class NaiveAdditiveDecisionTree extends SparseLtrRanker implements Accoun
 
         public float getThreshold() {
             return this.threshold;
+        }
+
+        public boolean getDefaultLeft() {
+            return this.defaultLeft;
         }
 
         /**

--- a/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
@@ -174,7 +174,7 @@ public class XGBoostJsonParser implements LtrRankerParser {
         private Float threshold;
         private Integer rightNodeId;
         private Integer leftNodeId;
-        // Ignored
+        // XGBoost per-node missing direction: the child a missing (NaN) feature value is routed to.
         private Integer missingNodeId;
         private Float leaf;
         private List<SplitParserState> children;
@@ -252,7 +252,11 @@ public class XGBoostJsonParser implements LtrRankerParser {
         }
 
         boolean splitHasValidChildren() {
-            return children.size() == 2 && leftNodeId.equals(children.get(0).nodeId) && rightNodeId.equals(children.get(1).nodeId);
+            if (children.size() != 2 || !leftNodeId.equals(children.get(0).nodeId) || !rightNodeId.equals(children.get(1).nodeId)) {
+                return false;
+            }
+            // If a missing direction is declared it must point to one of this split's children.
+            return missingNodeId == null || missingNodeId.equals(leftNodeId) || missingNodeId.equals(rightNodeId);
         }
 
         boolean isSplit() {
@@ -261,11 +265,13 @@ public class XGBoostJsonParser implements LtrRankerParser {
 
         Node toNode(FeatureSet set) {
             if (isSplit()) {
+                boolean defaultLeft = missingNodeId != null && missingNodeId.equals(leftNodeId);
                 return new NaiveAdditiveDecisionTree.Split(
                     children.get(0).toNode(set),
                     children.get(1).toNode(set),
                     set.featureOrdinal(split),
-                    threshold
+                    threshold,
+                    defaultLeft
                 );
             } else {
                 return new NaiveAdditiveDecisionTree.Leaf(leaf);

--- a/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParser.java
@@ -89,7 +89,8 @@ public class XGBoostRawJsonParser implements LtrRankerParser {
                 reorderTreeFeatures(splitNode.getLeft(), modelFeaturesReordering),
                 reorderTreeFeatures(splitNode.getRight(), modelFeaturesReordering),
                 modelFeaturesReordering.get(splitNode.getFeature()),
-                splitNode.getThreshold()
+                splitNode.getThreshold(),
+                splitNode.getDefaultLeft()
             );
         }
 
@@ -466,11 +467,13 @@ public class XGBoostRawJsonParser implements LtrRankerParser {
             }
 
             if (isSplit(nodeId)) {
+                boolean routeMissingLeft = defaultLeft != null && defaultLeft.get(nodeId) == 1;
                 return new NaiveAdditiveDecisionTree.Split(
                     asLibTree(leftChildren.get(nodeId)),
                     asLibTree(rightChildren.get(nodeId)),
                     splitIndices.get(nodeId),
-                    splitConditions.get(nodeId)
+                    splitConditions.get(nodeId),
+                    routeMissingLeft
                 );
             } else {
                 return new NaiveAdditiveDecisionTree.Leaf(baseWeights.get(nodeId));

--- a/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
@@ -76,6 +76,77 @@ public class XGBoostJsonParserTests extends LuceneTestCase {
         assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
     }
 
+    public void testMissingFeatureRoutedToYesChild() throws IOException {
+        // "missing" points at the "yes" child (leaf 0.5), which differs from the "no" child.
+        // A missing (NaN) feature must therefore be routed to the yes leaf, mirroring XGBoost.
+        String model = "[{"
+            + "\"nodeid\": 0,"
+            + "\"split\":\"feat1\","
+            + "\"depth\":0,"
+            + "\"split_condition\":100.0,"
+            + "\"yes\":1,"
+            + "\"no\": 2,"
+            + "\"missing\":1,"
+            + "\"children\": ["
+            + "   {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5},"
+            + "   {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
+            + "]}]";
+
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        // A fresh vector leaves feat1 unset (NaN), i.e. the feature is missing.
+        FeatureVector v = tree.newFeatureVector(null);
+        assertEquals(0.5F, tree.score(v), Math.ulp(0.5F));
+        // A present value below the threshold still takes the yes child.
+        v.setFeatureScore(0, 50F);
+        assertEquals(0.5F, tree.score(v), Math.ulp(0.5F));
+        // A present value at/above the threshold takes the no child.
+        v.setFeatureScore(0, 150F);
+        assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
+    }
+
+    public void testMissingFeatureRoutedToNoChild() throws IOException {
+        // "missing" points at the "no" child (leaf 0.2). A missing (NaN) feature routes there.
+        String model = "[{"
+            + "\"nodeid\": 0,"
+            + "\"split\":\"feat1\","
+            + "\"depth\":0,"
+            + "\"split_condition\":100.0,"
+            + "\"yes\":1,"
+            + "\"no\": 2,"
+            + "\"missing\":2,"
+            + "\"children\": ["
+            + "   {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5},"
+            + "   {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
+            + "]}]";
+
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        FeatureVector v = tree.newFeatureVector(null);
+        assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
+    }
+
+    public void testMissingPointsToInvalidChild() throws IOException {
+        // "missing" must point at one of the split's own children.
+        String model = "[{"
+            + "\"nodeid\": 0,"
+            + "\"split\":\"feat1\","
+            + "\"depth\":0,"
+            + "\"split_condition\":100.0,"
+            + "\"yes\":1,"
+            + "\"no\": 2,"
+            + "\"missing\":3,"
+            + "\"children\": ["
+            + "   {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5},"
+            + "   {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
+            + "]}]";
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+        assertThat(
+            expectThrows(ParsingException.class, () -> parser.parse(set, model)).getMessage(),
+            CoreMatchers.containsString("Split structure is invalid, yes, no and/or")
+        );
+    }
+
     public void testReadSimpleSplitInObject() throws IOException {
         String model = "{"
             + "\"splits\": [{"

--- a/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParserTests.java
@@ -102,6 +102,69 @@ public class XGBoostRawJsonParserTests extends LuceneTestCase {
         assertEquals(10.0, tree.score(featureVector), Math.ulp(0.1F));
     }
 
+    public void testMissingFeatureHonorsDefaultLeft() throws IOException {
+        String model = "{"
+            + "    \"learner\":{"
+            + "        \"attributes\":{},"
+            + "        \"feature_names\":[\"feat1\"],"
+            + "        \"feature_types\":[\"float\"],"
+            + "        \"gradient_booster\":{"
+            + "        \"model\":{"
+            + "            \"gbtree_model_param\":{"
+            + "            \"num_parallel_tree\":\"1\","
+            + "            \"num_trees\":\"1\"},"
+            + "            \"iteration_indptr\":[0,1],"
+            + "            \"tree_info\":[0],"
+            + "            \"trees\":[{"
+            + "                \"base_weights\":[1E0, 10E0, 0E0],"
+            + "                \"categories\":[],"
+            + "                \"categories_nodes\":[],"
+            + "                \"categories_segments\":[],"
+            + "                \"categories_sizes\":[],"
+            + "                \"default_left\":[1, 0, 0],"
+            + "                \"id\":0,"
+            + "                \"left_children\":[2, -1, -1],"
+            + "                \"loss_changes\":[0E0, 0E0, 0E0],"
+            + "                \"parents\":[2147483647, 0, 0],"
+            + "                \"right_children\":[1, -1, -1],"
+            + "                \"split_conditions\":[3E0, -1E0, -1E0],"
+            + "                \"split_indices\":[0, 0, 0],"
+            + "                \"split_type\":[0, 0, 0],"
+            + "                \"sum_hessian\":[1E0, 1E0, 1E0],"
+            + "                \"tree_param\":{"
+            + "                    \"num_deleted\":\"0\","
+            + "                    \"num_feature\":\"1\","
+            + "                    \"num_nodes\":\"3\","
+            + "                    \"size_leaf_vector\":\"1\"}"
+            + "                }"
+            + "            ]},"
+            + "            \"name\":\"gbtree\""
+            + "        },"
+            + "        \"learner_model_param\":{"
+            + "            \"base_score\":\"5E-1\","
+            + "            \"boost_from_average\":\"1\","
+            + "            \"num_class\":\"0\","
+            + "            \"num_feature\":\"1\","
+            + "            \"num_target\":\"1\""
+            + "        },"
+            + "        \"objective\":{"
+            + "            \"name\":\"reg:linear\","
+            + "            \"reg_loss_param\":{\"scale_pos_weight\":\"1\"}"
+            + "        }"
+            + "    },"
+            + "    \"version\":[2,1,0]"
+            + "}";
+
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        // A fresh vector leaves feat1 missing (NaN) -> default_left routes it to node 2 (score 0.0).
+        FeatureVector featureVector = tree.newFeatureVector(null);
+        assertEquals(0.0, tree.score(featureVector), Math.ulp(0.1F));
+        // Present values still branch on the threshold as usual.
+        featureVector.setFeatureScore(0, 4);
+        assertEquals(10.0, tree.score(featureVector), Math.ulp(0.1F));
+    }
+
     public void testReadWithLogisticObjective() throws IOException {
         String model = "{"
             + "    \"learner\":{"


### PR DESCRIPTION
### Description
Fixes a scoring regression where XGBoost models trained with `missing=NaN` (the XGBoost default) silently produce different rankings in OpenSearch than their offline predictions.

### Background

PR #206 switched `NaiveAdditiveDecisionTree` to a sparse feature vector where a missing feature defaults to `Float.NaN` (`SparseFeatureVector`), intending to reach parity with XGBoost's native missing-value handling. However, the tree evaluator never consulted XGBoost's per-node missing direction:

- `NaiveAdditiveDecisionTree.Split` stored only `{left, right, feature, threshold}` and evaluated `threshold > scores[feature]`. Because `threshold > NaN` is always `false`, a missing feature was **unconditionally routed to the `no`/right child** at every node.
- `XGBoostJsonParser` parsed the `"missing"` pointer into `missingNodeId` but marked it `// Ignored` and never passed it to the tree. `"default_left"` was not parsed.
- `XGBoostRawJsonParser` parsed `default_left` but never forwarded it to the `Split` constructor.

As a result, parity with a NaN-trained model only held for the subset of nodes whose learned missing direction happened to equal the `no` branch. For all other nodes the served score diverged from the model's prediction, with no error — so models retrained with `missing=np.nan` showed no metric recovery.

### Changes
  
  - **`NaiveAdditiveDecisionTree.Split`**: add a `defaultLeft` field (with getter). `eval()` now checks `Float.isNaN(value)` and, for missing features, routes by`defaultLeft` instead of the threshold comparison. A backward-compatible constructor preserves the previous route-right behavior for callers that have no missing direction (e.g. RankLib).
  - **`XGBoostJsonParser`**: honor the `"missing"` pointer — compute `defaultLeft = missing == yes` and validate that `"missing"` references one of the split's children.
  - **`XGBoostRawJsonParser`**: forward `default_left` into the `Split` constructor and preserve it through feature reordering.
  - **Tests**: unit tests for both parsers covering missing→yes, missing→no, and an invalid missing pointer; an integration test in `StoredLtrQueryIT` for the distinguishing `missing != no` case (which the pre-existing `missing == no` test could not detect).

### Behavior change / compatibility

This is backward-compatible:
  - Models whose learned missing direction already points to the `no` branch score identically to before.
  - Non-XGBoost rankers keep the default route-right behavior.
  - Models where `missing`/`default_left` points to the `yes` branch now score correctly (previously wrong), matching XGBoost's native `predict`.

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/378

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
