### PR TITLE
Add model-level missing_as_zero flag for XGBoost ranker (#286)

### DIFF
--- a/src/javaRestTest/java/com/o19s/es/ltr/query/StoredLtrQueryIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/query/StoredLtrQueryIT.java
@@ -429,6 +429,24 @@ public class StoredLtrQueryIT extends BaseIntegrationTest {
         + "   {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
         + "]}]";
 
+    // Object form with missing_as_zero=true; same "missing":2 as SIMPLE_MODEL_XGB (which scores 0.2),
+    // but a missing feature is treated as 0.0 (100 > 0 -> "yes") so it scores 0.5.
+    private static final String SIMPLE_MODEL_XGB_MISSING_AS_ZERO = "{"
+        + "\"missing_as_zero\": true,"
+        + "\"objective\": \"reg:linear\","
+        + "\"splits\": [{"
+        + "\"nodeid\": 0,"
+        + "\"split\":\"text_feature1\","
+        + "\"depth\":0,"
+        + "\"split_condition\":100.0,"
+        + "\"yes\":1,"
+        + "\"no\":2,"
+        + "\"missing\":2,"
+        + "\"children\": ["
+        + "   {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5},"
+        + "   {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
+        + "]}]}";
+
     public void testScriptFeatureUseCaseMissingFeatureNaiveAdditiveDecisionTree() throws Exception {
         assertMissingFeatureScore(SIMPLE_MODEL_XGB, 0.2F);
     }
@@ -436,6 +454,62 @@ public class StoredLtrQueryIT extends BaseIntegrationTest {
     public void testScriptFeatureUseCaseMissingFeatureRoutedByMissingDirection() throws Exception {
         // "missing":1 -> a missing feature must take the "yes" child (leaf 0.5), not the "no" child.
         assertMissingFeatureScore(SIMPLE_MODEL_XGB_MISSING_YES, 0.5F);
+    }
+
+    public void testMissingAsZeroModelScoresExplainsAndLogsZero() throws Exception {
+        // Model missing_as_zero=true: a missing feature is 0.0 -> routes "yes" (0.5), explain reports 0.00,
+        // and (with the log spec's missing_as_zero) _ltrlog records 0.0 for the missing feature.
+        StoredFeatureSet set = new StoredFeatureSet(
+            "my_set",
+            Collections
+                .singletonList(
+                    new StoredFeature(
+                        "text_feature1",
+                        Collections.singletonList("query"),
+                        "mustache",
+                        QueryBuilders.matchQuery("field1", "{{query}}").toString()
+                    )
+                )
+        );
+        addElement(set);
+        addElement(
+            new StoredLtrModel(
+                "my_model",
+                set,
+                new StoredLtrModel.LtrModelDefinition("model/xgboost+json", SIMPLE_MODEL_XGB_MISSING_AS_ZERO, true)
+            )
+        );
+        buildIndex();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("query", "bonjour");
+        StoredLtrQueryBuilder sbuilder = new StoredLtrQueryBuilder(LtrTestUtils.nullLoader())
+            .featureSetName("my_set")
+            .modelName("my_model")
+            .params(params)
+            .queryName("test")
+            .boost(1);
+        QueryBuilder query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()));
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .explain(true)
+            .fetchSource(true)
+            .size(10)
+            .ext(Collections.singletonList(new LoggingSearchExtBuilder().addQueryLogging("log", "test", true)));
+
+        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
+        SearchHit hit = resp.getHits().getAt(0);
+
+        // score: missing -> 0.0 -> "yes" -> 0.5
+        assertEquals(0.5F, hit.getScore(), Math.ulp(0.5F));
+        // explain: default value reported as 0.00 (not NaN), consistent with scoring
+        String explanation = hit.getExplanation().getDetails()[0].getDescription();
+        assertThat(explanation, containsString("default value of 0.00 used"));
+        // _ltrlog: missing feature logged as 0.0
+        Map<String, List<Map<String, Object>>> logs = hit.getFields().get("_ltrlog").getValue();
+        List<Map<String, Object>> log = logs.get("log");
+        assertEquals("text_feature1", log.get(0).get("name"));
+        assertEquals(0.0F, ((Number) log.get(0).get("value")).floatValue(), Math.ulp(0.0F));
     }
 
     private void assertMissingFeatureScore(String xgbModel, float expectedScore) throws Exception {

--- a/src/main/java/com/o19s/es/ltr/ranker/SparseFeatureVector.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/SparseFeatureVector.java
@@ -19,7 +19,11 @@ package com.o19s.es.ltr.ranker;
 public class SparseFeatureVector extends ArrayFeatureVector {
 
     public SparseFeatureVector(int size) {
-        super(size, Float.NaN);
+        this(size, Float.NaN);
+    }
+
+    public SparseFeatureVector(int size, float defaultValue) {
+        super(size, defaultValue);
         reset();
     }
 }

--- a/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
@@ -36,6 +36,7 @@ public class NaiveAdditiveDecisionTree extends SparseLtrRanker implements Accoun
     private final float[] weights;
     private final int modelSize;
     private final Normalizer normalizer;
+    private final boolean missingAsZero;
 
     /**
      * TODO: Constructor for these classes are strict and not really
@@ -48,16 +49,44 @@ public class NaiveAdditiveDecisionTree extends SparseLtrRanker implements Accoun
      * @param normalizer class to perform any normalization on model score
      */
     public NaiveAdditiveDecisionTree(Node[] trees, float[] weights, int modelSize, Normalizer normalizer) {
+        this(trees, weights, modelSize, normalizer, false);
+    }
+
+    /**
+     * @param missingAsZero when true, a missing/unset feature defaults to 0.0 instead of NaN, so it
+     *                      routes through each split as a real 0.0 would (bypassing the per-node
+     *                      default_left) and explanation/logging report 0.0 consistently. Restores
+     *                      parity for models trained with missing values imputed to 0 (issue #286).
+     */
+    public NaiveAdditiveDecisionTree(Node[] trees, float[] weights, int modelSize, Normalizer normalizer, boolean missingAsZero) {
         assert trees.length == weights.length;
         this.trees = trees;
         this.weights = weights;
         this.modelSize = modelSize;
         this.normalizer = normalizer;
+        this.missingAsZero = missingAsZero;
     }
 
     @Override
     public String name() {
         return "naive_additive_decision_tree";
+    }
+
+    public boolean isMissingAsZero() {
+        return missingAsZero;
+    }
+
+    @Override
+    public SparseFeatureVector newFeatureVector(FeatureVector reuse) {
+        float defaultValue = missingAsZero ? 0.0f : Float.NaN;
+        // Only reuse when the vector's default matches this ranker's; otherwise reset() would restore
+        // a stale default and score with the wrong missing value.
+        if (reuse instanceof SparseFeatureVector && Float.compare(((SparseFeatureVector) reuse).getDefaultScore(), defaultValue) == 0) {
+            SparseFeatureVector vector = (SparseFeatureVector) reuse;
+            vector.reset();
+            return vector;
+        }
+        return new SparseFeatureVector(size(), defaultValue);
     }
 
     @Override

--- a/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
@@ -59,7 +59,7 @@ public class XGBoostJsonParser implements LtrRankerParser {
         float[] weights = new float[trees.length];
         // Tree weights are already encoded in outputs
         Arrays.fill(weights, 1F);
-        return new NaiveAdditiveDecisionTree(trees, weights, set.size(), modelDefinition.normalizer);
+        return new NaiveAdditiveDecisionTree(trees, weights, set.size(), modelDefinition.normalizer, modelDefinition.missingAsZero);
     }
 
     private static class XGBoostDefinition {
@@ -68,10 +68,13 @@ public class XGBoostJsonParser implements LtrRankerParser {
             PARSER = new ObjectParser<>("xgboost_definition", XGBoostDefinition::new);
             PARSER.declareString(XGBoostDefinition::setNormalizer, new ParseField("objective"));
             PARSER.declareObjectArray(XGBoostDefinition::setSplitParserStates, SplitParserState::parse, new ParseField("splits"));
+            // Opt-in: treat missing (unset) features as 0.0 for models trained with fillna=0 (issue #286). Default false.
+            PARSER.declareBoolean(XGBoostDefinition::setMissingAsZero, new ParseField("missing_as_zero"));
         }
 
         private Normalizer normalizer;
         private List<SplitParserState> splitParserStates;
+        private boolean missingAsZero = false;
 
         public static XGBoostDefinition parse(XContentParser parser, FeatureSet set) throws IOException {
             XGBoostDefinition definition;
@@ -140,6 +143,10 @@ public class XGBoostJsonParser implements LtrRankerParser {
 
         void setSplitParserStates(List<SplitParserState> splitParserStates) {
             this.splitParserStates = splitParserStates;
+        }
+
+        void setMissingAsZero(boolean missingAsZero) {
+            this.missingAsZero = missingAsZero;
         }
 
         Node[] getTrees(FeatureSet set) {

--- a/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParser.java
@@ -76,7 +76,8 @@ public class XGBoostRawJsonParser implements LtrRankerParser {
             adjustedTrees,
             weights,
             set.size(),
-            modelDefinition.getLearner().getObjective().getNormalizer()
+            modelDefinition.getLearner().getObjective().getNormalizer(),
+            modelDefinition.missingAsZero
         );
     }
 
@@ -110,6 +111,8 @@ public class XGBoostRawJsonParser implements LtrRankerParser {
                     new ParseField("learner")
                 );
             PARSER.declareIntArray(XGBoostRawJsonParser.XGBoostDefinition::setVersion, new ParseField("version"));
+            // Opt-in: treat missing (unset) features as 0.0 for models trained with fillna=0 (issue #286). Default false.
+            PARSER.declareBoolean(XGBoostRawJsonParser.XGBoostDefinition::setMissingAsZero, new ParseField("missing_as_zero"));
         }
 
         public static XGBoostRawJsonParser.XGBoostDefinition parse(XContentParser parser, FeatureSet set) throws IOException {
@@ -178,6 +181,12 @@ public class XGBoostRawJsonParser implements LtrRankerParser {
 
         public List<Integer> getVersion() {
             return version;
+        }
+
+        private boolean missingAsZero = false;
+
+        public void setMissingAsZero(boolean missingAsZero) {
+            this.missingAsZero = missingAsZero;
         }
 
         public void setVersion(List<Integer> version) {

--- a/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
@@ -147,6 +147,39 @@ public class XGBoostJsonParserTests extends LuceneTestCase {
         );
     }
 
+    public void testMissingAsZeroTreatsMissingLikeExplicitZero() throws IOException {
+        // "missing":2 -> defaultLeft=false, so with NaN handling a missing feature routes to "no" (0.2).
+        // With missing_as_zero the unset slot defaults to 0.0 and routes as a real 0.0 would (100 > 0 -> "yes" -> 0.5).
+        String splits = "\"splits\": [{"
+            + "\"nodeid\": 0,"
+            + "\"split\":\"feat1\","
+            + "\"depth\":0,"
+            + "\"split_condition\":100.0,"
+            + "\"yes\":1,"
+            + "\"no\": 2,"
+            + "\"missing\":2,"
+            + "\"children\": ["
+            + "   {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5},"
+            + "   {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
+            + "]}]";
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+
+        NaiveAdditiveDecisionTree defaultTree = parser.parse(set, "{" + splits + "}");
+        assertFalse(defaultTree.isMissingAsZero());
+        assertTrue(Float.isNaN(defaultTree.newFeatureVector(null).getDefaultScore()));
+        assertEquals(0.2F, defaultTree.score(defaultTree.newFeatureVector(null)), Math.ulp(0.2F));
+
+        NaiveAdditiveDecisionTree zeroTree = parser.parse(set, "{\"missing_as_zero\": true, " + splits + "}");
+        assertTrue(zeroTree.isMissingAsZero());
+        assertEquals(0.0F, zeroTree.newFeatureVector(null).getDefaultScore(), 0.0F);
+        // Missing feature scores identically to an explicit 0.0, and both differ from the default (NaN) tree.
+        float missing = zeroTree.score(zeroTree.newFeatureVector(null));
+        FeatureVector explicitZero = zeroTree.newFeatureVector(null);
+        explicitZero.setFeatureScore(0, 0.0F);
+        assertEquals(0.5F, missing, Math.ulp(0.5F));
+        assertEquals(missing, zeroTree.score(explicitZero), 0.0F);
+    }
+
     public void testReadSimpleSplitInObject() throws IOException {
         String model = "{"
             + "\"splits\": [{"

--- a/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParserTests.java
@@ -165,6 +165,55 @@ public class XGBoostRawJsonParserTests extends LuceneTestCase {
         assertEquals(10.0, tree.score(featureVector), Math.ulp(0.1F));
     }
 
+    public void testMissingAsZeroOverridesDefaultLeftRaw() throws IOException {
+        // default_left=0 -> a missing (NaN) feature routes right (node 1, weight 10.0). With
+        // missing_as_zero the missing feature is 0.0 (< 3.0) and routes left (node 2, weight 0.0).
+        String body = "    \"learner\":{"
+            + "        \"attributes\":{},"
+            + "        \"feature_names\":[\"feat1\"],"
+            + "        \"feature_types\":[\"float\"],"
+            + "        \"gradient_booster\":{"
+            + "        \"model\":{"
+            + "            \"gbtree_model_param\":{\"num_parallel_tree\":\"1\",\"num_trees\":\"1\"},"
+            + "            \"iteration_indptr\":[0,1],"
+            + "            \"tree_info\":[0],"
+            + "            \"trees\":[{"
+            + "                \"base_weights\":[1E0, 10E0, 0E0],"
+            + "                \"categories\":[],"
+            + "                \"categories_nodes\":[],"
+            + "                \"categories_segments\":[],"
+            + "                \"categories_sizes\":[],"
+            + "                \"default_left\":[0, 0, 0],"
+            + "                \"id\":0,"
+            + "                \"left_children\":[2, -1, -1],"
+            + "                \"loss_changes\":[0E0, 0E0, 0E0],"
+            + "                \"parents\":[2147483647, 0, 0],"
+            + "                \"right_children\":[1, -1, -1],"
+            + "                \"split_conditions\":[3E0, -1E0, -1E0],"
+            + "                \"split_indices\":[0, 0, 0],"
+            + "                \"split_type\":[0, 0, 0],"
+            + "                \"sum_hessian\":[1E0, 1E0, 1E0],"
+            + "                \"tree_param\":{\"num_deleted\":\"0\",\"num_feature\":\"1\",\"num_nodes\":\"3\",\"size_leaf_vector\":\"1\"}"
+            + "                }"
+            + "            ]},"
+            + "            \"name\":\"gbtree\""
+            + "        },"
+            + "        \"learner_model_param\":{\"base_score\":\"5E-1\",\"num_class\":\"0\",\"num_feature\":\"1\",\"num_target\":\"1\"},"
+            + "        \"objective\":{\"name\":\"reg:linear\",\"reg_loss_param\":{\"scale_pos_weight\":\"1\"}}"
+            + "    },"
+            + "    \"version\":[2,1,0]"
+            + "}";
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+
+        NaiveAdditiveDecisionTree defaultTree = parser.parse(set, "{" + body);
+        assertFalse(defaultTree.isMissingAsZero());
+        assertEquals(10.0F, defaultTree.score(defaultTree.newFeatureVector(null)), Math.ulp(10.0F));
+
+        NaiveAdditiveDecisionTree zeroTree = parser.parse(set, "{\"missing_as_zero\": true," + body);
+        assertTrue(zeroTree.isMissingAsZero());
+        assertEquals(0.0F, zeroTree.score(zeroTree.newFeatureVector(null)), Math.ulp(0.1F));
+    }
+
     public void testReadWithLogisticObjective() throws IOException {
         String model = "{"
             + "    \"learner\":{"


### PR DESCRIPTION
### Description

OS 3.3 changed XGBoost LTR scoring so that a **missing** feature reaches the model as `NaN` (routed by the tree's per-node missing direction / `default_left`) instead of `0.0` (#200). Models that were **trained with missing values filled to `0`** — a common pipeline default — are silently re-ranked on 3.3+, because XGBoost's `default_left` for those splits is arbitrary with respect to the value `0`. This is the regression reported in #286.

This PR adds an **opt-in, model-level** flag so such models can restore the pre-3.3 behavior **without retraining**.

### Change

A new optional top-level boolean `missing_as_zero` in the `model/xgboost+json` definition (object form). When `true`, a missing (`NaN`) feature is routed as `0.0` using the normal threshold comparison, **overriding** the per-node missing direction. Default `false` preserves the current native-`NaN` (`default_left`) behavior, so existing models are unaffected.

```json
{
  "missing_as_zero": true,
  "objective": "reg:logistic",
  "splits": [ { "nodeid": 0, "split": "...", "split_condition": 100.0, "yes": 1, "no": 2, "missing": 2, "children": [ ... ] } ]
}
```

- `XGBoostJsonParser` — parse the optional `missing_as_zero` and thread it into the `Split` nodes.
- `NaiveAdditiveDecisionTree.Split` — when set, treat a `NaN` feature as `0.0` in routing (one `isNaN` check per split; no allocation; overrides `defaultLeft`).

It's supplied with the stored model definition (read once at model parse/upload time) — no query, featureset, or cluster-setting change.

### Testing

- Unit: `XGBoostJsonParserTests#testMissingAsZeroOverridesDefaultLeft` — same `missing:2` split routes to `no` (0.2) by default and to `yes` (0.5) with `missing_as_zero`; present values unaffected.
- Integration: `StoredLtrQueryIT#testScriptFeatureUseCaseMissingFeatureMissingAsZero` — end-to-end via `sltr`; the same model that scores `0.2` by default scores `0.5` with the flag.
- Ran locally: `compileJava`/`compileTestJava`, `spotlessCheck`, parser + dectree unit tests, and the `StoredLtrQueryIT` missing-feature integration tests — all pass.

### Related

- Addresses #286
- Behavior introduced by #200

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented (model-level `missing_as_zero` flag; see description).
- [x] Commits are signed per the DCO using `--signoff`.
