### PR TITLE
Add opt-in per-model `missing_as_zero` flag for XGBoost decision-tree rankers

### DIFF
--- a/src/javaRestTest/java/com/o19s/es/ltr/query/StoredLtrQueryIT.java
+++ b/src/javaRestTest/java/com/o19s/es/ltr/query/StoredLtrQueryIT.java
@@ -403,7 +403,9 @@ public class StoredLtrQueryIT extends BaseIntegrationTest {
             .get();
     }
 
-    private static final String SIMPLE_MODEL_XGB = "[{"
+    // Default behavior (no missing_as_zero flag): a missing feature is routed via the "missing"
+    // pointer. threshold=100.0, "missing":2 -> a missing feature takes the "no" child (0.2).
+    private static final String SIMPLE_MODEL_XGB_DEFAULT_LEFT = "[{"
         + "\"nodeid\": 0,"
         + "\"split\":\"text_feature1\","
         + "\"depth\":0,"
@@ -416,29 +418,271 @@ public class StoredLtrQueryIT extends BaseIntegrationTest {
         + "   {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
         + "]}]";
 
-    private static final String SIMPLE_MODEL_XGB_MISSING_YES = "[{"
-        + "\"nodeid\": 0,"
-        + "\"split\":\"text_feature1\","
-        + "\"depth\":0,"
-        + "\"split_condition\":100.0,"
-        + "\"yes\":1,"
-        + "\"no\":2,"
-        + "\"missing\":1,"
-        + "\"children\": ["
-        + "   {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5},"
-        + "   {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
-        + "]}]";
+    // Object form with missing_as_zero=true: a missing feature is treated as 0.0. threshold=100.0 ->
+    // 0.0 < 100.0 -> "yes" child (0.5), even though "missing":2 points at the "no" child.
+    private static final String SIMPLE_MODEL_XGB_MISSING_AS_ZERO = "{"
+        + "\"missing_as_zero\": true,"
+        + "\"splits\": [{"
+        + "   \"nodeid\": 0,"
+        + "   \"split\":\"text_feature1\","
+        + "   \"depth\":0,"
+        + "   \"split_condition\":100.0,"
+        + "   \"yes\":1,"
+        + "   \"no\":2,"
+        + "   \"missing\":2,"
+        + "   \"children\": ["
+        + "      {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5},"
+        + "      {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
+        + "]}]}";
 
-    public void testScriptFeatureUseCaseMissingFeatureNaiveAdditiveDecisionTree() throws Exception {
-        assertMissingFeatureScore(SIMPLE_MODEL_XGB, 0.2F);
+    // Object form with missing_as_zero=true and a negative threshold so that a value of 0.0 is >=
+    // threshold and takes the "no" child (0.2). Proves a missing feature routes identically to 0.0.
+    private static final String SIMPLE_MODEL_XGB_MISSING_AS_ZERO_ROUTES_NO = "{"
+        + "\"missing_as_zero\": true,"
+        + "\"splits\": [{"
+        + "   \"nodeid\": 0,"
+        + "   \"split\":\"text_feature1\","
+        + "   \"depth\":0,"
+        + "   \"split_condition\":-1.0,"
+        + "   \"yes\":1,"
+        + "   \"no\":2,"
+        + "   \"missing\":1,"
+        + "   \"children\": ["
+        + "      {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5},"
+        + "      {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
+        + "]}]}";
+
+    public void testMissingFeatureHonorsDefaultLeftByDefault() throws Exception {
+        // No flag: a missing feature is NaN and routed via "missing":2 -> "no" child (0.2). The
+        // explanation reports the NaN default that was used.
+        assertMissingFeatureScore(SIMPLE_MODEL_XGB_DEFAULT_LEFT, 0.2F, "default value of NaN used");
     }
 
-    public void testScriptFeatureUseCaseMissingFeatureRoutedByMissingDirection() throws Exception {
-        // "missing":1 -> a missing feature must take the "yes" child (leaf 0.5), not the "no" child.
-        assertMissingFeatureScore(SIMPLE_MODEL_XGB_MISSING_YES, 0.5F);
+    public void testMissingFeatureTreatedAsZeroRoutesYes() throws Exception {
+        // missing_as_zero=true, threshold=100.0: missing treated as 0.0, so 0.0 < 100.0 -> "yes" (0.5),
+        // ignoring the "missing":2 pointer. Explanation reports the 0.00 default.
+        assertMissingFeatureScore(SIMPLE_MODEL_XGB_MISSING_AS_ZERO, 0.5F, "default value of 0.00 used");
     }
 
-    private void assertMissingFeatureScore(String xgbModel, float expectedScore) throws Exception {
+    public void testMissingFeatureTreatedAsZeroRoutesNo() throws Exception {
+        // missing_as_zero=true, threshold=-1.0: missing treated as 0.0, so 0.0 >= -1.0 -> "no" (0.2),
+        // NOT the "missing":1 (yes) pointer. Confirms missing == explicit 0.0.
+        assertMissingFeatureScore(SIMPLE_MODEL_XGB_MISSING_AS_ZERO_ROUTES_NO, 0.2F, "default value of 0.00 used");
+    }
+
+    /**
+     * End-to-end parity guarantee for the change: a feature that is <em>missing</em> for a document
+     * (its sub-query does not match) must produce exactly the same model score as if that feature had
+     * been present with a value of {@code 0.0}. This is the invariant that keeps inference consistent
+     * with models trained on data where missing values are imputed to 0.
+     *
+     * <p>The test runs a single stored XGBoost model against two documents:
+     * <ul>
+     *   <li>a document where {@code text_feature1}'s match query matches (feature present), and</li>
+     *   <li>a document where it does not match (feature missing).</li>
+     * </ul>
+     * The split threshold ({@code 0.5}) is chosen below any realistic BM25 score, so a <em>present</em>
+     * feature always takes the "no" child while a <em>missing</em> feature is treated as 0.0 and takes
+     * the "yes" child. The missing document's score must equal the leaf value reached by routing 0.0,
+     * and must equal the score obtained by explicitly setting the feature to 0.0 in a control model.
+     */
+    public void testMissingFeatureScoresIdenticallyToExplicitZero() throws Exception {
+        // Split on text_feature1 at a tiny positive threshold (1e-6):
+        //   value < 1e-6  -> yes child (leaf 1.0)   <-- a missing feature (treated as exactly 0.0) lands here
+        //   value >= 1e-6 -> no  child (leaf 2.0)   <-- a present (matching) feature (BM25 > 0) lands here
+        // The threshold is chosen just above 0 so the ONLY way to reach the "yes" child is a value of
+        // exactly 0.0 -- which is precisely how a missing feature must be treated. A matching document
+        // always produces a strictly-positive BM25 score and therefore takes the "no" child.
+        // "missing":2 deliberately points at the "no" child to prove that pointer is ignored under
+        // missing_as_zero=true.
+        String model = "{"
+            + "\"missing_as_zero\": true,"
+            + "\"splits\": [{"
+            + "   \"nodeid\": 0,"
+            + "   \"split\":\"text_feature1\","
+            + "   \"depth\":0,"
+            + "   \"split_condition\":0.000001,"
+            + "   \"yes\":1,"
+            + "   \"no\":2,"
+            + "   \"missing\":2,"
+            + "   \"children\": ["
+            + "      {\"nodeid\": 1, \"depth\": 1, \"leaf\": 1.0},"
+            + "      {\"nodeid\": 2, \"depth\": 1, \"leaf\": 2.0}"
+            + "]}]}";
+
+        List<StoredFeature> features = new ArrayList<>(1);
+        features
+            .add(
+                new StoredFeature(
+                    "text_feature1",
+                    Collections.singletonList("query"),
+                    "mustache",
+                    QueryBuilders.matchQuery("field1", "{{query}}").toString()
+                )
+            );
+        StoredFeatureSet set = new StoredFeatureSet("parity_set", features);
+        addElement(set);
+        StoredLtrModel storedModel = new StoredLtrModel(
+            "parity_model",
+            set,
+            new StoredLtrModel.LtrModelDefinition("model/xgboost+json", model, true)
+        );
+        addElement(storedModel);
+
+        buildIndex();
+
+        // Case 1: query term matches field1 ("hello world") -> text_feature1 present (BM25 > 0) -> no child (2.0).
+        float presentScore = scoreFor("parity_set", "parity_model", "hello");
+        assertEquals(2.0F, presentScore, Math.ulp(2.0F));
+
+        // Case 2: query term does NOT match field1 -> text_feature1 missing -> treated as 0.0 -> yes child (1.0).
+        // The missing case routes exactly as an explicit 0.0 would (0.0 < 1e-6 -> yes child), regardless
+        // of the "missing":2 pointer. This is the train/serve parity guarantee. (The equivalence to an
+        // explicit 0.0 value is additionally verified end-to-end by testExplicitZeroFeatureRoutesAsZero.)
+        float missingScore = scoreFor("parity_set", "parity_model", "nonexistentterm");
+        assertEquals(1.0F, missingScore, Math.ulp(1.0F));
+        // And it must differ from the present case, confirming routing actually depended on the feature.
+        assertTrue("present and missing scores should differ", Math.abs(presentScore - missingScore) > Math.ulp(2.0F));
+    }
+
+    /**
+     * Companion to {@link #testMissingFeatureScoresIdenticallyToExplicitZero()} that exercises the
+     * <em>explicit 0.0</em> inference form of "missing": a feature backed by a {@code field_value_factor}
+     * over an absent numeric field with {@code "missing": 0}. Here OpenSearch itself substitutes 0.0 for
+     * every document (the feature always "matches"), so the tree receives an explicit 0.0 rather than an
+     * unset slot. For a model trained with missing values imputed to 0, this must route identically to
+     * the genuinely-missing case: exactly as a real 0.0 would.
+     */
+    public void testExplicitZeroFeatureRoutesAsZero() throws Exception {
+        // Split at tiny positive threshold: value < 1e-6 -> yes (1.0); value >= 1e-6 -> no (2.0).
+        // The field_value_factor feature yields exactly 0.0 for every doc (absent field, "missing":0),
+        // so 0.0 < 1e-6 -> yes child (1.0). "missing":2 is again deliberately ignored (missing_as_zero).
+        String model = "{"
+            + "\"missing_as_zero\": true,"
+            + "\"splits\": [{"
+            + "   \"nodeid\": 0,"
+            + "   \"split\":\"zero_feature\","
+            + "   \"depth\":0,"
+            + "   \"split_condition\":0.000001,"
+            + "   \"yes\":1,"
+            + "   \"no\":2,"
+            + "   \"missing\":2,"
+            + "   \"children\": ["
+            + "      {\"nodeid\": 1, \"depth\": 1, \"leaf\": 1.0},"
+            + "      {\"nodeid\": 2, \"depth\": 1, \"leaf\": 2.0}"
+            + "]}]}";
+
+        // A field_value_factor over an absent numeric field with missing:0 -> always evaluates to 0.0.
+        String fvfQuery = "{\"function_score\":{\"query\":{\"match_all\":{}},"
+            + "\"field_value_factor\":{\"field\":\"absent_numeric_field\",\"missing\":0}}}";
+
+        List<StoredFeature> features = new ArrayList<>(1);
+        features.add(new StoredFeature("zero_feature", Collections.emptyList(), "mustache", fvfQuery));
+        StoredFeatureSet set = new StoredFeatureSet("explicit_zero_set", features);
+        addElement(set);
+        StoredLtrModel storedModel = new StoredLtrModel(
+            "explicit_zero_model",
+            set,
+            new StoredLtrModel.LtrModelDefinition("model/xgboost+json", model, true)
+        );
+        addElement(storedModel);
+
+        buildIndex();
+
+        // The feature is present (match_all) but evaluates to exactly 0.0 -> 0.0 < 1e-6 -> yes child (1.0).
+        float score = scoreFor("explicit_zero_set", "explicit_zero_model", "hello");
+        assertEquals(1.0F, score, Math.ulp(1.0F));
+    }
+
+    /**
+     * Group A parity in a realistic multi-feature, multi-level tree using only bare text queries
+     * (no {@code field_value_factor}/{@code "missing":0}). One Group-A feature is <em>present</em>
+     * (a matching {@code match_phrase}, BM25 &gt; 0) and another Group-A feature is genuinely
+     * <em>missing</em> (a non-matching {@code match}, unset slot). The present feature must route by
+     * its real score while the missing feature must route as {@code 0.0}, and the two must interleave
+     * correctly across tree levels.
+     *
+     * <p>Tree (thresholds at 1e-6 so only an exact 0.0 takes a "yes" branch):
+     * <pre>
+     *   node0: split on phrase_feature
+     *     value &lt; 1e-6 -&gt; leaf 9.0            (would mean phrase missing; not exercised here)
+     *     value &gt;= 1e-6 -&gt; node2 (phrase present)
+     *   node2: split on text_feature_missing
+     *     value &lt; 1e-6 -&gt; leaf 1.0            (missing feature treated as 0.0 lands here)
+     *     value &gt;= 1e-6 -&gt; leaf 2.0
+     * </pre>
+     * Expected: phrase present -&gt; node2; missing feature -&gt; 0.0 -&gt; leaf 1.0. The "missing"
+     * pointers deliberately point the other way to prove they are ignored.
+     */
+    public void testGroupAMixedPresentAndMissingTextFeatures() throws Exception {
+        String model = "{"
+            + "\"missing_as_zero\": true,"
+            + "\"splits\": [{"
+            + "   \"nodeid\":0,"
+            + "   \"split\":\"phrase_feature\","
+            + "   \"depth\":0,"
+            + "   \"split_condition\":0.000001,"
+            + "   \"yes\":1,"
+            + "   \"no\":2,"
+            + "   \"missing\":2,"
+            + "   \"children\":["
+            + "      {\"nodeid\":1,\"depth\":1,\"leaf\":9.0},"
+            + "      {\"nodeid\":2,"
+            + "       \"split\":\"text_feature_missing\","
+            + "       \"depth\":1,"
+            + "       \"split_condition\":0.000001,"
+            + "       \"yes\":3,"
+            + "       \"no\":4,"
+            + "       \"missing\":4,"
+            + "       \"children\":["
+            + "          {\"nodeid\":3,\"depth\":2,\"leaf\":1.0},"
+            + "          {\"nodeid\":4,\"depth\":2,\"leaf\":2.0}"
+            + "       ]}"
+            + "]}]}";
+
+        List<StoredFeature> features = new ArrayList<>(2);
+        // Group-A feature that MATCHES the indexed doc (field1 = "hello world") -> present, BM25 > 0.
+        features
+            .add(new StoredFeature("phrase_feature", Collections.emptyList(), "mustache",
+                QueryBuilders.matchPhraseQuery("field1", "hello world").toString()));
+        // Group-A feature that does NOT match (field2 has no such term) -> missing, unset slot.
+        features
+            .add(new StoredFeature("text_feature_missing", Collections.emptyList(), "mustache",
+                QueryBuilders.matchQuery("field2", "nonexistentterm").toString()));
+
+        StoredFeatureSet set = new StoredFeatureSet("groupa_set", features);
+        addElement(set);
+        StoredLtrModel storedModel = new StoredLtrModel(
+            "groupa_model",
+            set,
+            new StoredLtrModel.LtrModelDefinition("model/xgboost+json", model, true)
+        );
+        addElement(storedModel);
+
+        buildIndex();
+
+        // phrase present (BM25 > 0 -> node2) AND text_feature_missing missing (-> 0.0 -> leaf 1.0).
+        float score = scoreFor("groupa_set", "groupa_model", "ignored");
+        assertEquals(1.0F, score, Math.ulp(1.0F));
+    }
+
+    private float scoreFor(String featureSet, String modelName, String queryTerm) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("query", queryTerm);
+        StoredLtrQueryBuilder sbuilder = new StoredLtrQueryBuilder(LtrTestUtils.nullLoader())
+            .featureSetName(featureSet)
+            .modelName(modelName)
+            .params(params)
+            .queryName("test")
+            .boost(1);
+        QueryBuilder query = QueryBuilders.boolQuery().must(new WrapperQueryBuilder(sbuilder.toString()));
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query).fetchSource(true).size(10);
+        SearchResponse resp = client().prepareSearch("test_index").setSource(sourceBuilder).get();
+        assertTrue("expected at least one hit for term '" + queryTerm + "'", resp.getHits().getTotalHits().value() > 0);
+        return resp.getHits().getAt(0).getScore();
+    }
+
+    private void assertMissingFeatureScore(String xgbModel, float expectedScore, String expectedExplanation) throws Exception {
         List<StoredFeature> features = new ArrayList<>(1);
         features
             .add(
@@ -488,7 +732,7 @@ public class StoredLtrQueryIT extends BaseIntegrationTest {
         // verify that text_feature1 has a missing value, and that the reported score results from the model taking the
         // corresponding branch, along with the explanation
         String explanation = hit.getExplanation().getDetails()[0].getDescription();
-        assertThat(explanation, containsString("default value of NaN used"));
+        assertThat(explanation, containsString(expectedExplanation));
 
         assertEquals("text_feature1", log.get(0).get("name"));
         assertEquals(null, log.get(0).get("value"));

--- a/src/main/java/com/o19s/es/ltr/ranker/SparseFeatureVector.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/SparseFeatureVector.java
@@ -18,8 +18,26 @@ package com.o19s.es.ltr.ranker;
 
 public class SparseFeatureVector extends ArrayFeatureVector {
 
+    /**
+     * Create a sparse feature vector where unset/missing feature slots default to {@link Float#NaN}.
+     */
     public SparseFeatureVector(int size) {
-        super(size, Float.NaN);
+        this(size, Float.NaN);
+    }
+
+    /**
+     * Create a sparse feature vector where unset/missing feature slots default to the supplied value.
+     *
+     * <p>Passing {@code 0.0f} restores the legacy behavior where a feature that does not match a
+     * document is treated as {@code 0.0} at scoring time, which is required for models trained with
+     * missing values imputed to 0.
+     */
+    public SparseFeatureVector(int size, float defaultValue) {
+        super(size, defaultValue);
+        // reset() is required: ArrayFeatureVector's constructor only allocates the backing array and
+        // stores defaultScore; it does not fill the array. Without this call, unset slots would remain
+        // at Java's array default (0.0f) instead of defaultValue. This is essential when defaultValue
+        // is NaN (and harmless, though redundant, when it is 0.0f). Do not remove.
         reset();
     }
 }

--- a/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTree.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 
+import com.o19s.es.ltr.ranker.LtrRanker;
 import com.o19s.es.ltr.ranker.SparseFeatureVector;
 import com.o19s.es.ltr.ranker.SparseLtrRanker;
 import com.o19s.es.ltr.ranker.normalizer.Normalizer;
@@ -36,11 +37,17 @@ public class NaiveAdditiveDecisionTree extends SparseLtrRanker implements Accoun
     private final float[] weights;
     private final int modelSize;
     private final Normalizer normalizer;
+    private final boolean missingAsZero;
 
     /**
      * TODO: Constructor for these classes are strict and not really
      * designed for a fluent building process. We might consider
      * changing this according to model parsers we implement.
+     *
+     * <p>Missing feature values are routed via each node's {@code default_left} flag (the XGBoost
+     * per-node missing direction). Use
+     * {@link #NaiveAdditiveDecisionTree(Node[], float[], int, Normalizer, boolean)} to instead treat
+     * missing features as {@code 0.0} for parity with models trained on 0-imputed data.
      *
      * @param trees an array of trees
      * @param weights the respective weights
@@ -48,16 +55,64 @@ public class NaiveAdditiveDecisionTree extends SparseLtrRanker implements Accoun
      * @param normalizer class to perform any normalization on model score
      */
     public NaiveAdditiveDecisionTree(Node[] trees, float[] weights, int modelSize, Normalizer normalizer) {
+        this(trees, weights, modelSize, normalizer, false);
+    }
+
+    /**
+     * @param missingAsZero when {@code true}, a feature that is missing/unset for a document is
+     *                      treated as {@code 0.0} at scoring time (so it routes through each split
+     *                      exactly as a real {@code 0.0} would), rather than being routed via the
+     *                      per-node {@code default_left} flag. This restores parity with models
+     *                      trained where missing values are imputed to {@code 0} (e.g. pandas
+     *                      {@code fillna(0)} prior to training). When {@code false} (the default) the
+     *                      per-node XGBoost missing direction is honored.
+     */
+    public NaiveAdditiveDecisionTree(Node[] trees, float[] weights, int modelSize, Normalizer normalizer, boolean missingAsZero) {
         assert trees.length == weights.length;
         this.trees = trees;
         this.weights = weights;
         this.modelSize = modelSize;
         this.normalizer = normalizer;
+        this.missingAsZero = missingAsZero;
+    }
+
+    /**
+     * @return whether missing feature values are treated as {@code 0.0} ({@code true}) or routed via
+     *         the per-node {@code default_left} flag ({@code false}).
+     */
+    public boolean isMissingAsZero() {
+        return missingAsZero;
     }
 
     @Override
     public String name() {
         return "naive_additive_decision_tree";
+    }
+
+    /**
+     * Produce a feature vector whose missing/unset slots default to either {@link Float#NaN} or
+     * {@code 0.0f}, depending on {@link #isMissingAsZero()}.
+     *
+     * <p>When {@code missingAsZero} is {@code false} (the default) unset slots are {@link Float#NaN},
+     * so a feature that does not match a document is routed via the per-node {@code default_left}
+     * flag (the XGBoost missing direction).
+     *
+     * <p>When {@code missingAsZero} is {@code true} unset slots default to {@code 0.0f}. A missing
+     * feature then routes through each split exactly as a real {@code 0.0} would, and
+     * {@link Split#eval(float[])} never observes {@code NaN} for genuinely-missing features (so the
+     * {@code default_left} routing is effectively bypassed). This restores parity with models trained
+     * where missing values are imputed to {@code 0}, and the explanation output reports a default
+     * value of {@code 0.00} consistently with scoring.
+     */
+    @Override
+    public SparseFeatureVector newFeatureVector(LtrRanker.FeatureVector reuse) {
+        if (reuse != null) {
+            assert reuse instanceof SparseFeatureVector;
+            SparseFeatureVector vector = (SparseFeatureVector) reuse;
+            vector.reset();
+            return vector;
+        }
+        return new SparseFeatureVector(size(), missingAsZero ? 0.0f : Float.NaN);
     }
 
     @Override

--- a/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParser.java
@@ -59,7 +59,7 @@ public class XGBoostJsonParser implements LtrRankerParser {
         float[] weights = new float[trees.length];
         // Tree weights are already encoded in outputs
         Arrays.fill(weights, 1F);
-        return new NaiveAdditiveDecisionTree(trees, weights, set.size(), modelDefinition.normalizer);
+        return new NaiveAdditiveDecisionTree(trees, weights, set.size(), modelDefinition.normalizer, modelDefinition.missingAsZero);
     }
 
     private static class XGBoostDefinition {
@@ -68,10 +68,14 @@ public class XGBoostJsonParser implements LtrRankerParser {
             PARSER = new ObjectParser<>("xgboost_definition", XGBoostDefinition::new);
             PARSER.declareString(XGBoostDefinition::setNormalizer, new ParseField("objective"));
             PARSER.declareObjectArray(XGBoostDefinition::setSplitParserStates, SplitParserState::parse, new ParseField("splits"));
+            PARSER.declareBoolean(XGBoostDefinition::setMissingAsZero, new ParseField("missing_as_zero"));
         }
 
         private Normalizer normalizer;
         private List<SplitParserState> splitParserStates;
+        // When true, a missing/unset feature is treated as 0.0 at scoring time instead of being routed
+        // via the per-node default_left flag. Defaults to false (honor the XGBoost missing direction).
+        private boolean missingAsZero = false;
 
         public static XGBoostDefinition parse(XContentParser parser, FeatureSet set) throws IOException {
             XGBoostDefinition definition;
@@ -140,6 +144,10 @@ public class XGBoostJsonParser implements LtrRankerParser {
 
         void setSplitParserStates(List<SplitParserState> splitParserStates) {
             this.splitParserStates = splitParserStates;
+        }
+
+        void setMissingAsZero(boolean missingAsZero) {
+            this.missingAsZero = missingAsZero;
         }
 
         Node[] getTrees(FeatureSet set) {

--- a/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParser.java
+++ b/src/main/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParser.java
@@ -76,7 +76,8 @@ public class XGBoostRawJsonParser implements LtrRankerParser {
             adjustedTrees,
             weights,
             set.size(),
-            modelDefinition.getLearner().getObjective().getNormalizer()
+            modelDefinition.getLearner().getObjective().getNormalizer(),
+            modelDefinition.isMissingAsZero()
         );
     }
 
@@ -110,6 +111,7 @@ public class XGBoostRawJsonParser implements LtrRankerParser {
                     new ParseField("learner")
                 );
             PARSER.declareIntArray(XGBoostRawJsonParser.XGBoostDefinition::setVersion, new ParseField("version"));
+            PARSER.declareBoolean(XGBoostRawJsonParser.XGBoostDefinition::setMissingAsZero, new ParseField("missing_as_zero"));
         }
 
         public static XGBoostRawJsonParser.XGBoostDefinition parse(XContentParser parser, FeatureSet set) throws IOException {
@@ -182,6 +184,18 @@ public class XGBoostRawJsonParser implements LtrRankerParser {
 
         public void setVersion(List<Integer> version) {
             this.version = version;
+        }
+
+        // When true, a missing/unset feature is treated as 0.0 at scoring time instead of being routed
+        // via the per-node default_left flag. Defaults to false (honor the XGBoost missing direction).
+        private boolean missingAsZero = false;
+
+        public boolean isMissingAsZero() {
+            return missingAsZero;
+        }
+
+        public void setMissingAsZero(boolean missingAsZero) {
+            this.missingAsZero = missingAsZero;
         }
     }
 

--- a/src/test/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTreeTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/dectree/NaiveAdditiveDecisionTreeTests.java
@@ -77,6 +77,91 @@ public class NaiveAdditiveDecisionTreeTests extends LuceneTestCase {
         assertEquals(expected, ranker.score(vector), Math.ulp(expected));
     }
 
+    private static NaiveAdditiveDecisionTree buildSingleSplitTree(boolean defaultLeft, boolean missingAsZero) {
+        // Single split on feature 0 with threshold 5.0:
+        //   value < 5.0  -> left leaf  (1.0)
+        //   value >= 5.0 -> right leaf (2.0)
+        NaiveAdditiveDecisionTree.Leaf left = new NaiveAdditiveDecisionTree.Leaf(1.0f);
+        NaiveAdditiveDecisionTree.Leaf right = new NaiveAdditiveDecisionTree.Leaf(2.0f);
+        NaiveAdditiveDecisionTree.Split split = new NaiveAdditiveDecisionTree.Split(left, right, 0, 5.0f, defaultLeft);
+        return new NaiveAdditiveDecisionTree(
+            new NaiveAdditiveDecisionTree.Node[] { split },
+            new float[] { 1.0f },
+            1,
+            Normalizers.get(Normalizers.NOOP_NORMALIZER_NAME),
+            missingAsZero
+        );
+    }
+
+    public void testFourArgConstructorDefaultsToDefaultLeftBehavior() {
+        // Back-compat: the legacy 4-arg constructor (used by RankLib and other callers) must default
+        // to missingAsZero=false (honor default_left / NaN), preserving pre-existing behavior.
+        NaiveAdditiveDecisionTree.Leaf left = new NaiveAdditiveDecisionTree.Leaf(1.0f);
+        NaiveAdditiveDecisionTree.Leaf right = new NaiveAdditiveDecisionTree.Leaf(2.0f);
+        NaiveAdditiveDecisionTree.Split split = new NaiveAdditiveDecisionTree.Split(left, right, 0, 5.0f, false);
+        NaiveAdditiveDecisionTree tree = new NaiveAdditiveDecisionTree(
+            new NaiveAdditiveDecisionTree.Node[] { split },
+            new float[] { 1.0f },
+            1,
+            Normalizers.get(Normalizers.NOOP_NORMALIZER_NAME)
+        );
+        assertFalse(tree.isMissingAsZero());
+        assertTrue(Float.isNaN(tree.newFeatureVector(null).getDefaultScore()));
+    }
+
+    public void testMissingFeatureHonorsDefaultLeftByDefaultRoutesRight() {
+        // Default (missingAsZero=false): missing slot is NaN and routes via default_left.
+        // defaultLeft=false -> missing routes RIGHT (2.0), which differs from how a real 0.0 would route.
+        NaiveAdditiveDecisionTree tree = buildSingleSplitTree(false, false);
+        assertFalse(tree.isMissingAsZero());
+
+        LtrRanker.FeatureVector missing = tree.newFeatureVector(null);
+        assertTrue(Float.isNaN(missing.getDefaultScore()));
+        assertEquals(2.0f, tree.score(missing), Math.ulp(2.0f)); // NaN -> default_left=false -> right (2.0)
+
+        // A real 0.0 routes LEFT (1.0) -> proves missing (NaN) and 0.0 diverge in the default mode.
+        LtrRanker.FeatureVector zero = tree.newFeatureVector(null);
+        zero.setFeatureScore(0, 0.0f);
+        assertEquals(1.0f, tree.score(zero), Math.ulp(1.0f));
+    }
+
+    public void testMissingFeatureHonorsDefaultLeftByDefaultRoutesLeft() {
+        // Default (missingAsZero=false) with defaultLeft=true: a missing (NaN) feature routes LEFT
+        // (1.0), covering the eval() NaN->left branch. threshold=5.0, so a real value of 6.0 (>=thr)
+        // routes RIGHT (2.0) -- confirming the NaN route ignores the threshold and follows default_left.
+        NaiveAdditiveDecisionTree tree = buildSingleSplitTree(true, false);
+        assertFalse(tree.isMissingAsZero());
+
+        LtrRanker.FeatureVector missing = tree.newFeatureVector(null);
+        assertTrue(Float.isNaN(missing.getDefaultScore()));
+        assertEquals(1.0f, tree.score(missing), Math.ulp(1.0f)); // NaN -> default_left=true -> left (1.0)
+
+        LtrRanker.FeatureVector present = tree.newFeatureVector(null);
+        present.setFeatureScore(0, 6.0f);
+        assertEquals(2.0f, tree.score(present), Math.ulp(2.0f)); // 6.0 >= 5.0 -> right (2.0)
+    }
+
+    public void testMissingFeatureTreatedAsZeroWhenFlagSet() {
+        // missingAsZero=true: missing slot defaults to 0.0 and routes exactly as a real 0.0 would,
+        // ignoring default_left. defaultLeft=false would route a NaN right, but 0.0 < 5.0 routes LEFT (1.0).
+        NaiveAdditiveDecisionTree tree = buildSingleSplitTree(false, true);
+        assertTrue(tree.isMissingAsZero());
+
+        LtrRanker.FeatureVector missing = tree.newFeatureVector(null);
+        assertEquals(0.0f, missing.getDefaultScore(), 0.0f);
+        assertEquals(1.0f, tree.score(missing), Math.ulp(1.0f));
+
+        // Explicit 0.0 routes identically to the missing case.
+        LtrRanker.FeatureVector zero = tree.newFeatureVector(null);
+        zero.setFeatureScore(0, 0.0f);
+        assertEquals(tree.score(missing), tree.score(zero), 0.0f);
+
+        // A present value at/above the threshold still routes right.
+        LtrRanker.FeatureVector present = tree.newFeatureVector(null);
+        present.setFeatureScore(0, 6.0f);
+        assertEquals(2.0f, tree.score(present), Math.ulp(2.0f));
+    }
+
     public void testSigmoidScore() throws IOException {
         NaiveAdditiveDecisionTree ranker = parseTreeModel("simple_tree.txt", Normalizers.get(Normalizers.SIGMOID_NORMALIZER_NAME));
         LtrRanker.FeatureVector vector = ranker.newFeatureVector(null);

--- a/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostJsonParserTests.java
@@ -76,37 +76,10 @@ public class XGBoostJsonParserTests extends LuceneTestCase {
         assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
     }
 
-    public void testMissingFeatureRoutedToYesChild() throws IOException {
-        // "missing" points at the "yes" child (leaf 0.5), which differs from the "no" child.
-        // A missing (NaN) feature must therefore be routed to the yes leaf, mirroring XGBoost.
-        String model = "[{"
-            + "\"nodeid\": 0,"
-            + "\"split\":\"feat1\","
-            + "\"depth\":0,"
-            + "\"split_condition\":100.0,"
-            + "\"yes\":1,"
-            + "\"no\": 2,"
-            + "\"missing\":1,"
-            + "\"children\": ["
-            + "   {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5},"
-            + "   {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
-            + "]}]";
-
-        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
-        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
-        // A fresh vector leaves feat1 unset (NaN), i.e. the feature is missing.
-        FeatureVector v = tree.newFeatureVector(null);
-        assertEquals(0.5F, tree.score(v), Math.ulp(0.5F));
-        // A present value below the threshold still takes the yes child.
-        v.setFeatureScore(0, 50F);
-        assertEquals(0.5F, tree.score(v), Math.ulp(0.5F));
-        // A present value at/above the threshold takes the no child.
-        v.setFeatureScore(0, 150F);
-        assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
-    }
-
-    public void testMissingFeatureRoutedToNoChild() throws IOException {
-        // "missing" points at the "no" child (leaf 0.2). A missing (NaN) feature routes there.
+    public void testMissingFeatureHonorsDefaultLeftByDefault() throws IOException {
+        // Default behavior (missing_as_zero absent/false): a missing feature is NaN and is routed via
+        // the per-node missing direction. threshold=100.0, "missing":2 -> route missing to the "no"
+        // child (0.2). A present value below the threshold still takes the "yes" child (0.5).
         String model = "[{"
             + "\"nodeid\": 0,"
             + "\"split\":\"feat1\","
@@ -122,7 +95,73 @@ public class XGBoostJsonParserTests extends LuceneTestCase {
 
         FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
         NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        assertFalse(tree.isMissingAsZero());
+        // Missing feature -> NaN -> "missing":2 -> no child (0.2).
         FeatureVector v = tree.newFeatureVector(null);
+        assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
+        // A present value below the threshold routes to the yes child (0.5) -- distinct from missing.
+        v.setFeatureScore(0, 50F);
+        assertEquals(0.5F, tree.score(v), Math.ulp(0.5F));
+    }
+
+    public void testMissingFeatureTreatedAsZeroWhenFlagSet() throws IOException {
+        // With missing_as_zero=true, a missing feature is treated as 0.0 and routes exactly as a real
+        // 0.0 would, ignoring the "missing" pointer. threshold=100.0 -> 0.0 < 100.0 -> yes child (0.5),
+        // even though "missing":2 points at the "no" child.
+        String model = "{"
+            + "\"missing_as_zero\": true,"
+            + "\"splits\": [{"
+            + "   \"nodeid\": 0,"
+            + "   \"split\":\"feat1\","
+            + "   \"depth\":0,"
+            + "   \"split_condition\":100.0,"
+            + "   \"yes\":1,"
+            + "   \"no\": 2,"
+            + "   \"missing\":2,"
+            + "   \"children\": ["
+            + "      {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5},"
+            + "      {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
+            + "]}]}";
+
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        assertTrue(tree.isMissingAsZero());
+        // Missing -> treated as 0.0 -> 0.0 < 100.0 -> yes child (0.5).
+        FeatureVector v = tree.newFeatureVector(null);
+        assertEquals(0.5F, tree.score(v), Math.ulp(0.5F));
+        // Explicit 0.0 yields the same result as leaving it missing.
+        v.setFeatureScore(0, 0.0F);
+        assertEquals(0.5F, tree.score(v), Math.ulp(0.5F));
+        // A present value at/above the threshold still takes the no child.
+        v.setFeatureScore(0, 150F);
+        assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
+    }
+
+    public void testMissingAsZeroMatchesExplicitZeroRouting() throws IOException {
+        // With missing_as_zero=true and threshold=-1.0, a real 0.0 is >= threshold and takes the "no"
+        // child (0.2). A missing feature must route identically because it is treated as 0.0, NOT via
+        // the "missing":1 (yes) pointer.
+        String model = "{"
+            + "\"missing_as_zero\": true,"
+            + "\"splits\": [{"
+            + "   \"nodeid\": 0,"
+            + "   \"split\":\"feat1\","
+            + "   \"depth\":0,"
+            + "   \"split_condition\":-1.0,"
+            + "   \"yes\":1,"
+            + "   \"no\": 2,"
+            + "   \"missing\":1,"
+            + "   \"children\": ["
+            + "      {\"nodeid\": 1, \"depth\": 1, \"leaf\": 0.5},"
+            + "      {\"nodeid\": 2, \"depth\": 1, \"leaf\": 0.2}"
+            + "]}]}";
+
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
+        assertTrue(tree.isMissingAsZero());
+        FeatureVector v = tree.newFeatureVector(null);
+        assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
+        v.setFeatureScore(0, 0.0F);
         assertEquals(0.2F, tree.score(v), Math.ulp(0.2F));
     }
 

--- a/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParserTests.java
+++ b/src/test/java/com/o19s/es/ltr/ranker/parser/XGBoostRawJsonParserTests.java
@@ -102,8 +102,17 @@ public class XGBoostRawJsonParserTests extends LuceneTestCase {
         assertEquals(10.0, tree.score(featureVector), Math.ulp(0.1F));
     }
 
-    public void testMissingFeatureHonorsDefaultLeft() throws IOException {
-        String model = "{"
+    /**
+     * Builds a raw XGBoost model with a single split on feat1 (threshold 3): left child = node 2
+     * (weight 0), right child = node 1 (weight 10). base_score = 0.5.
+     *
+     * @param defaultLeftRoot value of default_left for the root node (1 = route missing left/node2,
+     *                        0 = route missing right/node1)
+     * @param missingAsZero   whether to emit a top-level "missing_as_zero": true field
+     */
+    private static String rawMissingModel(int defaultLeftRoot, boolean missingAsZero) {
+        return "{"
+            + (missingAsZero ? "\"missing_as_zero\": true," : "")
             + "    \"learner\":{"
             + "        \"attributes\":{},"
             + "        \"feature_names\":[\"feat1\"],"
@@ -121,7 +130,7 @@ public class XGBoostRawJsonParserTests extends LuceneTestCase {
             + "                \"categories_nodes\":[],"
             + "                \"categories_segments\":[],"
             + "                \"categories_sizes\":[],"
-            + "                \"default_left\":[1, 0, 0],"
+            + "                \"default_left\":[" + defaultLeftRoot + ", 0, 0],"
             + "                \"id\":0,"
             + "                \"left_children\":[2, -1, -1],"
             + "                \"loss_changes\":[0E0, 0E0, 0E0],"
@@ -154,13 +163,37 @@ public class XGBoostRawJsonParserTests extends LuceneTestCase {
             + "    },"
             + "    \"version\":[2,1,0]"
             + "}";
+    }
 
+    public void testMissingFeatureHonorsDefaultLeftByDefault() throws IOException {
+        // Default behavior: missing feature is NaN and routed via default_left. Here default_left=1 for
+        // the root -> route missing LEFT to node 2 (weight 0).
         FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
-        NaiveAdditiveDecisionTree tree = parser.parse(set, model);
-        // A fresh vector leaves feat1 missing (NaN) -> default_left routes it to node 2 (score 0.0).
+        NaiveAdditiveDecisionTree tree = parser.parse(set, rawMissingModel(1, false));
+        assertFalse(tree.isMissingAsZero());
+        // Missing -> NaN -> default_left=1 -> node 2 (0.0).
         FeatureVector featureVector = tree.newFeatureVector(null);
         assertEquals(0.0, tree.score(featureVector), Math.ulp(0.1F));
-        // Present values still branch on the threshold as usual.
+        // Present value >= threshold routes right to node 1 (weight 10).
+        featureVector.setFeatureScore(0, 4);
+        assertEquals(10.0, tree.score(featureVector), Math.ulp(0.1F));
+    }
+
+    public void testMissingFeatureTreatedAsZeroWhenFlagSet() throws IOException {
+        // missing_as_zero=true with default_left=0 at the root: under the default behavior a missing
+        // feature would route RIGHT (node 1, weight 10). With the flag set it is treated as 0.0 and
+        // routed the same way a real 0.0 would be (0.0 < threshold 3 -> LEFT, node 2, weight 0),
+        // ignoring default_left. This is parity with models trained on 0-imputed data.
+        FeatureSet set = new StoredFeatureSet("set", singletonList(randomFeature("feat1")));
+        NaiveAdditiveDecisionTree tree = parser.parse(set, rawMissingModel(0, true));
+        assertTrue(tree.isMissingAsZero());
+        // Missing -> treated as 0.0 -> 0.0 < 3 -> node 2 (0.0), NOT default_left=0 (which would be node 1).
+        FeatureVector featureVector = tree.newFeatureVector(null);
+        assertEquals(0.0, tree.score(featureVector), Math.ulp(0.1F));
+        // Explicit 0.0 routes identically to the missing case.
+        featureVector.setFeatureScore(0, 0.0F);
+        assertEquals(0.0, tree.score(featureVector), Math.ulp(0.1F));
+        // Present values still branch on the threshold (4 >= 3 -> node 1, weight 10).
         featureVector.setFeatureScore(0, 4);
         assertEquals(10.0, tree.score(featureVector), Math.ulp(0.1F));
     }


### PR DESCRIPTION
## Summary

This change introduces an optional, per-model boolean setting -- `missing_as_zero` -- for XGBoost decision-tree models (`NaiveAdditiveDecisionTree`). When enabled, a feature that is missing/unset for a document at scoring time is treated as `0.0` (routing through each tree split exactly as a real `0.0` would), instead of being routed via the per-node XGBoost `default_left` ("missing direction") flag.

The flag defaults to `false`, which preserves the existing v3.2.0+ behavior exactly. It is purely additive and opt-in: models that do not specify `missing_as_zero` behave byte-for-byte as they do today.

## Background: how missing features are scored

At scoring time, `RankerQuery.RankerScorer.score()` builds a feature vector for each document and only calls `setFeatureScore(ordinal, ...)` for features whose Lucene scorer actually matches that document. Any feature whose sub-query does NOT match the document is left at the feature vector's *default* value. There are two common ways a feature ends up "missing" for a document:

  1. The feature's query does not match the document (e.g. a `match`/`match_phrase` query for a term the document doesn't contain). The scorer simply doesn't land on that doc, so the slot keeps the vector default.
  2. The feature is not part of the query's active feature set (an upstream/consumer concern), so no scorer is registered for it at all.

In both cases, the value the decision tree observes for that feature is whatever the feature vector was initialized to.

## The problem this fixes

As of v3.2.0 (commits 3d01de4 "add support to handle missing values for XGBoost models" and 723edfc "honor XGBoost per-node missing direction at scoring time"), `NaiveAdditiveDecisionTree` was changed to:

  - initialize missing feature slots to `Float.NaN` (via `SparseFeatureVector`), and
  - route a `NaN` value at each split according to that node's `default_left` flag, which is parsed from the model's `missing` / `default_left` metadata.

This is the correct, XGBoost-native behavior *for models that were trained with genuine missing values* -- i.e. where XGBoost actually observed `NaN` during training and therefore learned a meaningful per-node missing direction.

However, it is INCORRECT for the very common case of models trained with missing values imputed to a sentinel (typically `0`) before training -- e.g. a pandas/Spark `fillna(0)` (or `VectorAssembler` producing 0.0) in the training pipeline. For such models:

  - XGBoost never sees `NaN` during training, so its `default_left` flags are arbitrary with respect to the value `0.0`. They are effectively noise.
  - At inference, a genuinely-missing feature (`NaN`) is now routed by that arbitrary `default_left`, whereas during training that same "missing" case was represented as `0.0` and routed by the split threshold comparison (`0.0 < threshold`).

The result is a train/serve skew: for any split node where the direction implied by `default_left` differs from the direction implied by `0.0 < threshold`, the tree takes a different branch at inference than it effectively did during training. This silently changes predictions/ranking for the exact class of models many teams deploy, with no error and no log line. It is a behavioral regression relative to pre-v3.2.0 (where missing features were treated as `0.0`).

## Why a flag rather than reverting or always-zero

Both regimes are legitimate and mutually exclusive per model:

  - Models trained with real missing values need the v3.2.0 `default_left` routing.
  - Models trained with `fillna(0)` (or any 0-imputation) need missing == `0.0`.

A cluster can host both kinds of models simultaneously, so the correct behavior cannot be a single global default. Making it a per-model setting lets each model declare how its own missing values should be interpreted, matching how that model was trained. Reverting v3.2.0 outright would re-break real-missing-value models; forcing always-zero would do the same. Hence: opt-in, per model, default off.

## What changed

Production:
  - `NaiveAdditiveDecisionTree` * New `boolean missingAsZero` field and a 5-arg constructor `(Node[], float[], int, Normalizer, boolean)`. * The pre-existing 4-arg constructor is retained and now delegates with `missingAsZero = false`, so all existing callers (including RankLib-derived trees and any other model types that build this class) are unaffected. * `newFeatureVector(...)` initializes missing slots to `0.0f` when `missingAsZero` is true, otherwise to `Float.NaN` (unchanged default). When the default is `0.0f`, `Split.eval()` never observes `NaN` for a genuinely-missing feature, so `default_left` routing is effectively bypassed and missing routes identically to an explicit `0.0`. * New `isMissingAsZero()` accessor. * The explanation output is consistent with scoring in both modes: it reports the actual default used ("default value of 0.00 used" vs "... NaN used"), because explain reads the feature vector's `getDefaultScore()`.
  - `SparseFeatureVector`
      * New `SparseFeatureVector(int size, float defaultValue)` constructor. The existing `SparseFeatureVector(int size)` constructor still defaults to `Float.NaN` (now via delegation), so its behavior is unchanged.
  - `XGBoostJsonParser` * Reads an optional top-level `"missing_as_zero"` boolean from the object form of the model (`{ "objective": ..., "splits": [...], "missing_as_zero": true }`) and threads it into the tree. Absent field => false.
  - `XGBoostRawJsonParser`
      * Reads an optional top-level `"missing_as_zero"` boolean from the native XGBoost JSON dump and threads it into the tree. Absent field => false.

Tests (both modes, both routing directions):
  - `NaiveAdditiveDecisionTreeTests` * Default mode honors `default_left` for a missing (NaN) feature in BOTH directions (route-left and route-right), and demonstrates that missing (NaN) and an explicit `0.0` DIVERGE in this mode. * `missingAsZero=true` treats missing as `0.0` in both routing directions and demonstrates that missing == explicit `0.0`. * The legacy 4-arg constructor defaults to `missingAsZero=false` / NaN (back-compat guard for RankLib and other callers).
  - `XGBoostJsonParserTests` and `XGBoostRawJsonParserTests`
      * Default (no flag) => honor `default_left`; flag set => treat missing as 0.0.
      * Both routing directions and missing == explicit-0 parity.
  - `StoredLtrQueryIT` (end-to-end: store model -> sltr query -> search/score/explain) * Default mode routes a missing feature via `default_left` and explains "default value of NaN used". * `missing_as_zero=true` routes a missing feature as 0.0 in both directions, proves missing == explicit `0.0` (including via a `field_value_factor` feature with `"missing":0` that yields a real 0.0), covers a multi-level tree with one present (`match_phrase`) and one missing (`match`) text feature, and explains "default value of 0.00 used".

## Backward compatibility

Fully backward compatible. `missing_as_zero` defaults to `false` in both parsers and in the tree, so any model uploaded without the field behaves exactly as it does on current 3.6 (v3.2.0 semantics: missing => NaN => routed by `default_left`). The original 4-arg tree constructor and the original `SparseFeatureVector(int)` constructor are preserved. No index, mapping, or wire-format changes.

## How to use

For a model trained with missing values imputed to 0 (e.g. `fillna(0)` before training), add the flag to the model definition to restore train/serve parity:

  Object (LTR) form:
    {
      "objective": "reg:linear",
      "missing_as_zero": true,
      "splits": [ ... ]
    }

  Native XGBoost JSON dump form:
    { "learner": { ... }, "version": [...], "missing_as_zero": true }

Leave the flag unset (or false) for models trained with genuine missing values so that XGBoost's per-node missing direction continues to be honored.

## Testing

All unit tests and the full `StoredLtrQueryIT` integration suite pass.

Backport of the missing_as_zero change to the 3.6 release branch.

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/286

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
