### PR TITLE
Make ltr.caches.max_mem dynamic and scale its default with heap

### DIFF
--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -313,6 +313,9 @@ public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, Script
 
         LTRSettings.getInstance().init(clusterService);
 
+        caches.setThreadPool(threadPool);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(Caches.LTR_CACHE_MEM_SETTING, caches::setMaxMem);
+
         final JvmService jvmService = new JvmService(environment.settings());
         final LTRCircuitBreakerService ltrCircuitBreakerService = new LTRCircuitBreakerService(jvmService).init();
 

--- a/src/main/java/com/o19s/es/ltr/feature/store/index/Caches.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/index/Caches.java
@@ -27,6 +27,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.common.CheckedFunction;
@@ -34,9 +36,11 @@ import org.opensearch.common.cache.Cache;
 import org.opensearch.common.cache.CacheBuilder;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.MemorySizeValue;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.monitor.jvm.JvmInfo;
+import org.opensearch.threadpool.ThreadPool;
 
 import com.o19s.es.ltr.feature.Feature;
 import com.o19s.es.ltr.feature.FeatureSet;
@@ -46,6 +50,8 @@ import com.o19s.es.ltr.feature.store.CompiledLtrModel;
  * Store various caches used by the plugin
  */
 public class Caches {
+    private static final Logger logger = LogManager.getLogger(Caches.class);
+
     public static final Setting<ByteSizeValue> LTR_CACHE_MEM_SETTING;
     public static final Setting<TimeValue> LTR_CACHE_EXPIRE_AFTER_WRITE = Setting
         .timeSetting("ltr.caches.expire_after_write", TimeValue.timeValueHours(1), TimeValue.timeValueNanos(0), Setting.Property.NodeScope);
@@ -56,17 +62,36 @@ public class Caches {
     private final Cache<CacheKey, FeatureSet> featureSetCache;
     private final Cache<CacheKey, CompiledLtrModel> modelCache;
 
-    static {
-        LTR_CACHE_MEM_SETTING = Setting
-            .memorySizeSetting(
-                "ltr.caches.max_mem",
-                (s) -> new ByteSizeValue(Math.min(RamUsageEstimator.ONE_MB * 10, JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() / 10))
-                    .toString(),
-                Setting.Property.NodeScope
-            );
+    static ByteSizeValue defaultMaxMem(long heapBytes) {
+        long tenMb = RamUsageEstimator.ONE_MB * 10;
+        return new ByteSizeValue(Math.min(heapBytes / 10, Math.max(heapBytes / 100, tenMb)));
     }
+
+    static {
+        LTR_CACHE_MEM_SETTING = new Setting<>(
+            new Setting.SimpleKey("ltr.caches.max_mem"),
+            // getStringRep, not toString: the latter rounds to one decimal and the parser rejects fractions.
+            (s) -> defaultMaxMem(JvmInfo.jvmInfo().getMem().getHeapMax().getBytes()).getStringRep(),
+            (s) -> MemorySizeValue.parseBytesSizeValueOrHeapRatio(s, "ltr.caches.max_mem"),
+            Caches::validateMaxMem,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+    }
+
+    /**
+     * {@link ByteSizeValue} accepts the unit-less value -1, which {@link Cache#setMaximumWeight} then
+     * rejects. Validating here fails the update request instead of failing later on every node.
+     */
+    private static void validateMaxMem(ByteSizeValue value) {
+        if (value.getBytes() < 0) {
+            throw new IllegalArgumentException("ltr.caches.max_mem must not be negative, got [" + value + "]");
+        }
+    }
+
     private final Map<String, PerStoreStats> perStoreStats = new ConcurrentHashMap<>();
-    private final long maxWeight;
+    private volatile ByteSizeValue maxWeight;
+    private volatile ThreadPool threadPool;
 
     public Caches(TimeValue expAfterWrite, TimeValue expAfterAccess, ByteSizeValue maxWeight) {
         this.featureCache = configCache(CacheBuilder.<CacheKey, Feature>builder(), expAfterWrite, expAfterAccess, maxWeight)
@@ -81,7 +106,41 @@ public class Caches {
             .weigher((s, w) -> w.ramBytesUsed())
             .removalListener((l) -> this.onRemove(l.getKey(), l.getValue()))
             .build();
-        this.maxWeight = maxWeight.getBytes();
+        this.maxWeight = maxWeight;
+    }
+
+    /** Evicting down to a smaller limit can take a while, so keep it off the cluster applier thread. */
+    public void setThreadPool(ThreadPool threadPool) {
+        this.threadPool = threadPool;
+    }
+
+    /**
+     * Applies a new per-cache memory limit in place. Entries are kept when growing; when shrinking, the
+     * caches evict down to the new limit.
+     */
+    public synchronized void setMaxMem(ByteSizeValue newMaxMem) {
+        long previous = maxWeight.getBytes();
+        if (newMaxMem.getBytes() == previous) {
+            return;
+        }
+        maxWeight = newMaxMem;
+        featureCache.setMaximumWeight(newMaxMem.getBytes());
+        featureSetCache.setMaximumWeight(newMaxMem.getBytes());
+        modelCache.setMaximumWeight(newMaxMem.getBytes());
+        logger.info("ltr.caches.max_mem updated from [{}] to [{}] per cache", new ByteSizeValue(previous), newMaxMem);
+        if (newMaxMem.getBytes() < previous) {
+            if (threadPool != null) {
+                threadPool.executor(ThreadPool.Names.GENERIC).execute(this::refresh);
+            } else {
+                refresh();
+            }
+        }
+    }
+
+    private void refresh() {
+        featureCache.refresh();
+        featureSetCache.refresh();
+        modelCache.refresh();
     }
 
     public static long weigther(CacheKey key, Object data) {
@@ -205,7 +264,7 @@ public class Caches {
     }
 
     public long getMaxWeight() {
-        return maxWeight;
+        return maxWeight.getBytes();
     }
 
     public static class CacheKey {

--- a/src/main/java/com/o19s/es/ltr/feature/store/index/Caches.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/index/Caches.java
@@ -85,7 +85,7 @@ public class Caches {
      */
     private static void validateMaxMem(ByteSizeValue value) {
         if (value.getBytes() < 0) {
-            throw new IllegalArgumentException("ltr.caches.max_mem must not be negative, got [" + value + "]");
+            throw new IllegalArgumentException("ltr.caches.max_mem must not be negative");
         }
     }
 

--- a/src/main/java/com/o19s/es/ltr/feature/store/index/Caches.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/index/Caches.java
@@ -36,7 +36,6 @@ import org.opensearch.common.cache.Cache;
 import org.opensearch.common.cache.CacheBuilder;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.unit.MemorySizeValue;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.monitor.jvm.JvmInfo;
@@ -52,6 +51,7 @@ import com.o19s.es.ltr.feature.store.CompiledLtrModel;
 public class Caches {
     private static final Logger logger = LogManager.getLogger(Caches.class);
 
+    static final String MAX_MEM_KEY = "ltr.caches.max_mem";
     public static final Setting<ByteSizeValue> LTR_CACHE_MEM_SETTING;
     public static final Setting<TimeValue> LTR_CACHE_EXPIRE_AFTER_WRITE = Setting
         .timeSetting("ltr.caches.expire_after_write", TimeValue.timeValueHours(1), TimeValue.timeValueNanos(0), Setting.Property.NodeScope);
@@ -62,6 +62,14 @@ public class Caches {
     private final Cache<CacheKey, FeatureSet> featureSetCache;
     private final Cache<CacheKey, CompiledLtrModel> modelCache;
 
+    /**
+     * The limit bounds each of the three caches (feature, feature set, model) independently, so the real
+     * per-node ceiling is {@code 3 * max_mem}. There is no aggregate cap; {@link org.opensearch.ltr.breaker.LTRCircuitBreakerService}
+     * guards overall JVM usage but does not bound these caches. Above this fraction of heap the aggregate is
+     * logged as a warning, since the value is operator-controlled and this is almost certainly larger than intended.
+     */
+    static final double AGGREGATE_HEAP_WARN_FRACTION = 0.25;
+
     static ByteSizeValue defaultMaxMem(long heapBytes) {
         long tenMb = RamUsageEstimator.ONE_MB * 10;
         return new ByteSizeValue(Math.min(heapBytes / 10, Math.max(heapBytes / 100, tenMb)));
@@ -69,10 +77,10 @@ public class Caches {
 
     static {
         LTR_CACHE_MEM_SETTING = new Setting<>(
-            new Setting.SimpleKey("ltr.caches.max_mem"),
+            new Setting.SimpleKey(MAX_MEM_KEY),
             // getStringRep, not toString: the latter rounds to one decimal and the parser rejects fractions.
             (s) -> defaultMaxMem(JvmInfo.jvmInfo().getMem().getHeapMax().getBytes()).getStringRep(),
-            (s) -> MemorySizeValue.parseBytesSizeValueOrHeapRatio(s, "ltr.caches.max_mem"),
+            new Setting.MemorySizeValueParser(MAX_MEM_KEY),
             Caches::validateMaxMem,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
@@ -85,7 +93,7 @@ public class Caches {
      */
     private static void validateMaxMem(ByteSizeValue value) {
         if (value.getBytes() < 0) {
-            throw new IllegalArgumentException("ltr.caches.max_mem must not be negative");
+            throw new IllegalArgumentException(MAX_MEM_KEY + " must not be negative");
         }
     }
 
@@ -107,6 +115,7 @@ public class Caches {
             .removalListener((l) -> this.onRemove(l.getKey(), l.getValue()))
             .build();
         this.maxWeight = maxWeight;
+        warnIfAggregateExceedsHeap(maxWeight);
     }
 
     /** Evicting down to a smaller limit can take a while, so keep it off the cluster applier thread. */
@@ -116,7 +125,8 @@ public class Caches {
 
     /**
      * Applies a new per-cache memory limit in place. Entries are kept when growing; when shrinking, the
-     * caches evict down to the new limit.
+     * caches evict down to the new limit. The limit applies to each of the three caches independently, so
+     * the aggregate ceiling this establishes is {@code 3 * newMaxMem}.
      */
     public synchronized void setMaxMem(ByteSizeValue newMaxMem) {
         long previous = maxWeight.getBytes();
@@ -127,13 +137,39 @@ public class Caches {
         featureCache.setMaximumWeight(newMaxMem.getBytes());
         featureSetCache.setMaximumWeight(newMaxMem.getBytes());
         modelCache.setMaximumWeight(newMaxMem.getBytes());
-        logger.info("ltr.caches.max_mem updated from [{}] to [{}] per cache", new ByteSizeValue(previous), newMaxMem);
+        logger.info("{} updated from [{}] to [{}] per cache", MAX_MEM_KEY, new ByteSizeValue(previous), newMaxMem);
+        warnIfAggregateExceedsHeap(newMaxMem);
         if (newMaxMem.getBytes() < previous) {
             if (threadPool != null) {
                 threadPool.executor(ThreadPool.Names.GENERIC).execute(this::refresh);
             } else {
                 refresh();
             }
+        }
+    }
+
+    /**
+     * The limit is not an allocation; it only caps how much each cache may hold. It is operator-controlled and
+     * intentionally not bounded, so a large value is accepted, but {@code 3 * max_mem} above a sizable fraction
+     * of heap is almost certainly a misconfiguration and is worth surfacing.
+     */
+    private static void warnIfAggregateExceedsHeap(ByteSizeValue perCacheLimit) {
+        long heapMax = JvmInfo.jvmInfo().getMem().getHeapMax().getBytes();
+        if (heapMax <= 0) {
+            return;
+        }
+        long aggregate = perCacheLimit.getBytes() * 3;
+        if (aggregate > heapMax * AGGREGATE_HEAP_WARN_FRACTION) {
+            logger
+                .warn(
+                    "{} is [{}] per cache; the three LTR caches together may use up to [{}], which is over {}% of the [{}] heap. "
+                        + "This is not pre-allocated and the circuit breaker still guards the JVM, but verify this value is intended.",
+                    MAX_MEM_KEY,
+                    perCacheLimit,
+                    new ByteSizeValue(aggregate),
+                    (int) (AGGREGATE_HEAP_WARN_FRACTION * 100),
+                    new ByteSizeValue(heapMax)
+                );
         }
     }
 

--- a/src/test/java/com/o19s/es/ltr/feature/store/index/CachesTests.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/index/CachesTests.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright [2017] Wikimedia Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.o19s.es.ltr.feature.store.index;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.MemorySizeValue;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.common.unit.ByteSizeValue;
+
+import com.o19s.es.ltr.LtrTestUtils;
+import com.o19s.es.ltr.feature.store.CompiledLtrModel;
+import com.o19s.es.ltr.feature.store.MemStore;
+import com.o19s.es.ltr.feature.store.StoredFeature;
+import com.o19s.es.ltr.feature.store.StoredFeatureSet;
+
+public class CachesTests extends LuceneTestCase {
+    private static final long ONE_MB = RamUsageEstimator.ONE_MB;
+
+    private Caches newCaches(ByteSizeValue maxMem) {
+        return new Caches(TimeValue.timeValueHours(1), TimeValue.timeValueHours(1), maxMem);
+    }
+
+    public void testDefaultScalesWithHeapAndNeverShrinks() {
+        // Below ~100mb of heap the heap/10 term keeps the historical small-heap behaviour.
+        assertEquals(ONE_MB * 64 / 10, Caches.defaultMaxMem(ONE_MB * 64).getBytes());
+        assertEquals(ONE_MB * 10, Caches.defaultMaxMem(ONE_MB * 100).getBytes());
+        // From ~1gb upwards the limit tracks 1% of heap.
+        assertEquals(ONE_MB * 1024 / 100, Caches.defaultMaxMem(ONE_MB * 1024).getBytes());
+        assertEquals(ONE_MB * 16384 / 100, Caches.defaultMaxMem(ONE_MB * 16384).getBytes());
+
+        // The new default is never below the previous min(10mb, heap/10) default.
+        for (long heap : new long[] { 0, 1, ONE_MB, ONE_MB * 64, ONE_MB * 512, ONE_MB * 1024, ONE_MB * 8192, ONE_MB * 31 * 1024 }) {
+            assertTrue(Caches.defaultMaxMem(heap).getBytes() >= Math.min(ONE_MB * 10, heap / 10));
+        }
+    }
+
+    public void testDefaultParsesBackAtEveryHeapSize() {
+        // The default is handed to the setting as a string, so it has to survive its own parser.
+        for (long heap : new long[] { 0, 1, ONE_MB, ONE_MB * 512, ONE_MB * 1024, ONE_MB * 8192, ONE_MB * 31 * 1024 }) {
+            ByteSizeValue expected = Caches.defaultMaxMem(heap);
+            ByteSizeValue parsed = MemorySizeValue.parseBytesSizeValueOrHeapRatio(expected.getStringRep(), "ltr.caches.max_mem");
+            assertEquals(expected.getBytes(), parsed.getBytes());
+        }
+    }
+
+    public void testRejectsNegativeLimit() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> Caches.LTR_CACHE_MEM_SETTING.get(Settings.builder().put("ltr.caches.max_mem", "-1").build())
+        );
+        assertTrue(e.getMessage().contains("must not be negative"));
+    }
+
+    public void testAcceptsValuesValidBeforeThisChange() {
+        // These were accepted when the setting was static and must keep working on upgrade.
+        for (String value : new String[] { "0", "512kb", "1024kb", "100mb", "1%" }) {
+            Caches.LTR_CACHE_MEM_SETTING.get(Settings.builder().put("ltr.caches.max_mem", value).build());
+        }
+    }
+
+    public void testGrowingKeepsCachedEntries() throws IOException {
+        MemStore memStore = new MemStore();
+        StoredFeature feat = LtrTestUtils.randomFeature();
+        memStore.add(feat);
+
+        Caches caches = newCaches(new ByteSizeValue(ONE_MB * 10));
+        CachedFeatureStore store = new CachedFeatureStore(memStore, caches);
+        store.load(feat.name());
+        assertNotNull(store.getCachedFeature(feat.name()));
+
+        caches.setMaxMem(new ByteSizeValue(ONE_MB * 50));
+
+        assertEquals(ONE_MB * 50, caches.getMaxWeight());
+        assertEquals(ONE_MB * 50, caches.featureCache().getMaximumWeight());
+        assertEquals(ONE_MB * 50, caches.featureSetCache().getMaximumWeight());
+        assertEquals(ONE_MB * 50, caches.modelCache().getMaximumWeight());
+        // Growing must not discard warm entries or reset accounting.
+        assertNotNull(store.getCachedFeature(feat.name()));
+        assertEquals(feat.ramBytesUsed(), caches.getPerStoreStats(memStore.getStoreName()).totalRam());
+        assertEquals(1, caches.getPerStoreStats(memStore.getStoreName()).totalCount());
+    }
+
+    public void testShrinkingEvictsAllThreeCachesDownToNewLimit() throws IOException {
+        MemStore memStore = new MemStore();
+        StoredFeature feat = LtrTestUtils.randomFeature();
+        StoredFeatureSet set = LtrTestUtils.randomFeatureSet();
+        CompiledLtrModel model = LtrTestUtils.buildRandomModel();
+        memStore.add(feat);
+        memStore.add(set);
+        memStore.add(model);
+
+        Caches caches = newCaches(new ByteSizeValue(ONE_MB * 10));
+        CachedFeatureStore store = new CachedFeatureStore(memStore, caches);
+        store.load(feat.name());
+        store.loadSet(set.name());
+        store.loadModel(model.name());
+        assertEquals(3, caches.getPerStoreStats(memStore.getStoreName()).totalCount());
+
+        // A limit below every cached entry's weight must evict all three caches and unwind their stats.
+        caches.setMaxMem(new ByteSizeValue(1));
+
+        assertEquals(1, caches.getMaxWeight());
+        assertEquals(0, caches.featureCache().count());
+        assertEquals(0, caches.featureSetCache().count());
+        assertEquals(0, caches.modelCache().count());
+        assertEquals(0, caches.getPerStoreStats(memStore.getStoreName()).totalCount());
+        assertEquals(0, caches.getPerStoreStats(memStore.getStoreName()).totalRam());
+    }
+
+    public void testClusterSettingsUpdateAppliesTheNewLimit() {
+        Caches caches = newCaches(new ByteSizeValue(ONE_MB * 10));
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, Collections.singleton(Caches.LTR_CACHE_MEM_SETTING));
+        clusterSettings.addSettingsUpdateConsumer(Caches.LTR_CACHE_MEM_SETTING, caches::setMaxMem);
+
+        clusterSettings.applySettings(Settings.builder().put("ltr.caches.max_mem", "50mb").build());
+        assertEquals(ONE_MB * 50, caches.getMaxWeight());
+
+        // A negative value is refused by the dry run, so it never reaches the consumer.
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> clusterSettings.validateUpdate(Settings.builder().put("ltr.caches.max_mem", "-1").build())
+        );
+        assertEquals(ONE_MB * 50, caches.getMaxWeight());
+    }
+
+    public void testOnlyMaxMemIsDynamic() {
+        assertTrue(Caches.LTR_CACHE_MEM_SETTING.isDynamic());
+        assertFalse(Caches.LTR_CACHE_EXPIRE_AFTER_WRITE.isDynamic());
+        assertFalse(Caches.LTR_CACHE_EXPIRE_AFTER_READ.isDynamic());
+    }
+}

--- a/src/test/java/com/o19s/es/ltr/feature/store/index/CachesTests.java
+++ b/src/test/java/com/o19s/es/ltr/feature/store/index/CachesTests.java
@@ -18,6 +18,7 @@ package com.o19s.es.ltr.feature.store.index;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.RamUsageEstimator;
@@ -26,6 +27,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.MemorySizeValue;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
 
 import com.o19s.es.ltr.LtrTestUtils;
 import com.o19s.es.ltr.feature.store.CompiledLtrModel;
@@ -116,6 +119,9 @@ public class CachesTests extends LuceneTestCase {
         store.loadModel(model.name());
         assertEquals(3, caches.getPerStoreStats(memStore.getStoreName()).totalCount());
 
+        // No thread pool is installed, so setMaxMem evicts synchronously (Caches.java falls back to an inline
+        // refresh). This deliberately exercises the eviction *logic*; the async GENERIC-pool dispatch that runs
+        // in production is covered separately by testShrinkingEvictsViaGenericThreadPool.
         // A limit below every cached entry's weight must evict all three caches and unwind their stats.
         caches.setMaxMem(new ByteSizeValue(1));
 
@@ -125,6 +131,59 @@ public class CachesTests extends LuceneTestCase {
         assertEquals(0, caches.modelCache().count());
         assertEquals(0, caches.getPerStoreStats(memStore.getStoreName()).totalCount());
         assertEquals(0, caches.getPerStoreStats(memStore.getStoreName()).totalRam());
+    }
+
+    public void testShrinkingEvictsViaGenericThreadPool() throws Exception {
+        // In production threadPool is always non-null (installed in LtrQueryParserPlugin.createComponents), so a
+        // shrink dispatches refresh() to the GENERIC pool and eviction is asynchronous. This is the branch the
+        // synchronous test above cannot reach.
+        ThreadPool threadPool = new TestThreadPool("CachesTests");
+        try {
+            MemStore memStore = new MemStore();
+            StoredFeature feat = LtrTestUtils.randomFeature();
+            StoredFeatureSet set = LtrTestUtils.randomFeatureSet();
+            CompiledLtrModel model = LtrTestUtils.buildRandomModel();
+            memStore.add(feat);
+            memStore.add(set);
+            memStore.add(model);
+
+            Caches caches = newCaches(new ByteSizeValue(ONE_MB * 10));
+            caches.setThreadPool(threadPool);
+            CachedFeatureStore store = new CachedFeatureStore(memStore, caches);
+            store.load(feat.name());
+            store.loadSet(set.name());
+            store.loadModel(model.name());
+            assertEquals(3, caches.getPerStoreStats(memStore.getStoreName()).totalCount());
+
+            caches.setMaxMem(new ByteSizeValue(1));
+
+            // The limit is applied synchronously; only the eviction is dispatched to the pool.
+            assertEquals(1, caches.getMaxWeight());
+
+            // Eviction and stats unwinding happen on the GENERIC pool, so wait for them to complete.
+            assertBusy(caches, memStore.getStoreName());
+        } finally {
+            ThreadPool.terminate(threadPool, 5, TimeUnit.SECONDS);
+        }
+    }
+
+    // LuceneTestCase does not expose OpenSearchTestCase#assertBusy, so poll the async eviction directly.
+    private static void assertBusy(Caches caches, String storeName) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            if (caches.featureCache().count() == 0
+                && caches.featureSetCache().count() == 0
+                && caches.modelCache().count() == 0
+                && caches.getPerStoreStats(storeName).totalCount() == 0) {
+                break;
+            }
+            Thread.sleep(50);
+        }
+        assertEquals(0, caches.featureCache().count());
+        assertEquals(0, caches.featureSetCache().count());
+        assertEquals(0, caches.modelCache().count());
+        assertEquals(0, caches.getPerStoreStats(storeName).totalCount());
+        assertEquals(0, caches.getPerStoreStats(storeName).totalRam());
     }
 
     public void testClusterSettingsUpdateAppliesTheNewLimit() {


### PR DESCRIPTION
### Description

Two related changes to `ltr.caches.max_mem`.

**The default no longer scales with heap.** It is defined as `min(10mb, heap/10)`. The `heap/10` term only wins below 100mb of heap, so on every production node the default resolves to exactly 10mb, whether the node has 2gb of heap or 30gb. This changes it to `min(heap/10, max(heap/100, 10mb))`, which tracks 1% of heap on real nodes and is never below the previous value at any heap size, so no existing deployment gets a smaller cache.

A compiled XGBoost or LambdaMART model of 500 to 1000 trees at depth 6 measures 2mb to 4mb. Measured with `RamUsageEstimator` against the accounting in `NaiveAdditiveDecisionTree`:

| Trees | Depth | Reported size |
|---|---|---|
| 500 | 6 | 1.94 mb |
| 1000 | 6 | 3.88 mb |
| 500 | 8 | 7.80 mb |

Note that `max_mem` bounds each of the three caches separately, and the model cache is the one that matters here. A 10mb limit holds two or three models, so anyone comparing model variants in an A/B test evicts and recompiles on the search path. Raising the limit today requires editing `opensearch.yml` and restarting every node.

For comparison, `indices.requests.cache.size` defaults to 1% of heap and `indices.fielddata.cache.size` defaults to 35%.

**`ltr.caches.max_mem` is now dynamic.** Updates apply through `_cluster/settings` without a restart. The two `expire_after_*` settings stay static, because `Cache.setExpireAfterAccessNanos` and `setExpireAfterWriteNanos` are package private and unreachable from this package. Changing those two at runtime requires discarding and rebuilding the caches.

Resizing follows `IndicesFieldDataCache.updateMaximumWeight`. The limit is applied to the existing caches with `Cache.setMaximumWeight`, entries survive when the limit grows, and shrinking evicts down to the new limit on the generic thread pool instead of the cluster applier thread. Growing the cache keeps warm models, since a cold cache causes the recompilation this setting exists to avoid.

A validator rejects negative values. `ByteSizeValue` accepts the unit-less value `-1`, and the cluster settings dry run does not call update consumers. Without the validator, a `-1` passes validation and then throws from `Cache.setMaximumWeight` as each node applies the new cluster state.

Values that were valid before this change, including `0`, `512kb`, and percentages, are still accepted.

### Note on memory accounting

Cache weight comes from each cached object's `ramBytesUsed()`. Coverage is complete for the decision tree and linear rankers, which report their full object graph. RankLib rankers do not implement `Accountable`, so `CompiledLtrModel` substitutes a small placeholder for the ranker and under-reports those models. For RankLib models the limit is an approximation, not an exact bound. This behavior is unchanged by this PR and belongs in a separate change, since correcting it raises reported cache usage for deployments using those models and needs its own release note.

### Testing

`CachesTests` covers the default across heap sizes including the boundaries and zero, that the new default is never below the old one, that the default string parses back to the same byte count at every heap size, negative rejection, acceptance of previously valid values, in place growth preserving entries and stats, shrinking evicting all three caches and unwinding stats, applying the setting through `ClusterSettings`, and that only `max_mem` is dynamic.

The default reaches the setting as a string, so it has to survive its own parser. `ByteSizeValue.toString()` rounds to one decimal and `parseBytesSizeValue` rejects fractional values, which makes `getStringRep()` the correct choice here. Since the unit test JVM defaults to 512mb of heap, where the default resolves to exactly `10mb` and hides this, the suite was also run at 4gb and 16gb.

`./gradlew test spotlessCheck forbiddenApisMain licenseHeaders` passes at 512mb, 4gb, and 16gb heap, 307 tests.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented. These settings live on the OpenSearch documentation site, not in this repository, so the default change and the new dynamic property need a separate documentation-website PR. I will open that one.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
