### PR TITLE
Remove --refresh-dependencies from build script (opensearch-learning-to-rank-base)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -70,7 +70,7 @@ fi
 
 mkdir -p $OUTPUT
 
-./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew assemble --no-daemon -Drepos.mavenLocal=true -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 
 zipPath=$(find . -path \*build/distributions/*.zip)
 distributions="$(dirname "${zipPath}")"


### PR DESCRIPTION
### Description
Remove --refresh-dependencies from build script (opensearch-learning-to-rank-base)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5148963803