### PR TITLE
Adds a `QueryBuilderProtoConverter` SPI implementation for `sltr` gRPC support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ opensearchplugin {
   name 'opensearch-ltr'
   description 'Learning to Rank Query w/ RankLib Models'
   classname 'com.o19s.es.ltr.LtrQueryParserPlugin'
+  extendedPlugins = ['transport-grpc']
   // license of the plugin, may be different than the above license
   licenseFile = rootProject.file('LICENSE.txt')
   // copyright notices, may be different than the above notice
@@ -143,6 +144,8 @@ dependencies {
   implementation 'org.slf4j:slf4j-api:2.0.17'
   testImplementation 'org.slf4j:slf4j-simple:2.0.17'
   implementation "org.opensearch:common-utils:${common_utils_version}"
+  compileOnly "org.opensearch.plugin:transport-grpc-spi:${opensearch_version}"
+  compileOnly "org.opensearch:protobufs:${versions.opensearchprotobufs}"
 
   runtimeOnly 'org.locationtech.spatial4j:spatial4j:0.7'
   runtimeOnly 'org.locationtech.jts:jts-core:1.15.0'

--- a/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
+++ b/src/main/java/com/o19s/es/ltr/LtrQueryParserPlugin.java
@@ -341,11 +341,20 @@ public class LtrQueryParserPlugin extends Plugin implements SearchPlugin, Script
         return new LTRStats((stats));
     }
 
-    protected FeatureStoreLoader getFeatureStoreLoader() {
+    public FeatureStoreLoader getFeatureStoreLoader() {
         return (storeName, clientSupplier) -> new CachedFeatureStore(
             new IndexFeatureStore(storeName, clientSupplier, parserFactory),
             caches
         );
+    }
+
+    /**
+     * Exposes the plugin's {@link LTRStats} instance so the gRPC {@code sltr} query converter
+     * (registered via the transport-grpc {@code QueryBuilderProtoConverter} SPI) can build
+     * {@link StoredLtrQueryBuilder} instances with the same stats used by the REST path.
+     */
+    public LTRStats getLtrStats() {
+        return ltrStats;
     }
 
     // A simplified version of some token filters needed by the feature stores.

--- a/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilderProtoConverter.java
+++ b/src/main/java/com/o19s/es/ltr/query/StoredLtrQueryBuilderProtoConverter.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.o19s.es.ltr.query;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.ltr.stats.LTRStats;
+import org.opensearch.protobufs.ObjectMap;
+import org.opensearch.protobufs.QueryContainer;
+import org.opensearch.protobufs.StoredLtrQuery;
+import org.opensearch.transport.grpc.spi.QueryBuilderProtoConverter;
+
+import com.o19s.es.ltr.LtrQueryParserPlugin;
+import com.o19s.es.ltr.utils.FeatureStoreLoader;
+
+/**
+ * Converts a protobuf {@link StoredLtrQuery} ({@code sltr}) message into a
+ * {@link StoredLtrQueryBuilder} so that LTR queries can be issued over the gRPC transport.
+ *
+ * <p>This converter is registered with the transport-grpc module via the
+ * {@link QueryBuilderProtoConverter} SPI (see the {@code META-INF/services} descriptor). Because
+ * {@link StoredLtrQueryBuilder} requires a {@link FeatureStoreLoader} and {@link LTRStats} that are
+ * only available on the running {@link LtrQueryParserPlugin}, the converter is constructed with the
+ * plugin instance (the extension loader supports a single-argument constructor taking the extending
+ * plugin) and pulls those dependencies from it.
+ */
+public class StoredLtrQueryBuilderProtoConverter implements QueryBuilderProtoConverter {
+
+    private final FeatureStoreLoader storeLoader;
+    private final LTRStats ltrStats;
+
+    /**
+     * Constructs the converter from the LTR plugin, obtaining the feature-store loader and stats
+     * needed to build {@link StoredLtrQueryBuilder} instances.
+     *
+     * @param plugin the LTR plugin instance, injected by the extension loader
+     */
+    public StoredLtrQueryBuilderProtoConverter(LtrQueryParserPlugin plugin) {
+        this.storeLoader = plugin.getFeatureStoreLoader();
+        this.ltrStats = plugin.getLtrStats();
+    }
+
+    @Override
+    public QueryContainer.QueryContainerCase getHandledQueryCase() {
+        return QueryContainer.QueryContainerCase.SLTR;
+    }
+
+    @Override
+    public QueryBuilder fromProto(QueryContainer queryContainer) {
+        if (queryContainer == null || queryContainer.getQueryContainerCase() != QueryContainer.QueryContainerCase.SLTR) {
+            throw new IllegalArgumentException("QueryContainer does not contain an sltr query");
+        }
+
+        StoredLtrQuery proto = queryContainer.getSltr();
+
+        StoredLtrQueryBuilder builder = new StoredLtrQueryBuilder(storeLoader);
+        builder.ltrStats(ltrStats);
+
+        if (proto.hasModel()) {
+            builder.modelName(proto.getModel());
+        }
+        if (proto.hasFeatureset()) {
+            builder.featureSetName(proto.getFeatureset());
+        }
+        if (proto.hasStore()) {
+            builder.storeName(proto.getStore());
+        }
+        if (proto.hasCache()) {
+            builder.featureScoreCacheFlag(proto.getCache());
+        }
+        if (proto.hasParams()) {
+            builder.params(fromObjectMap(proto.getParams()));
+        }
+        if (proto.getActiveFeaturesCount() > 0) {
+            builder.activeFeatures(new ArrayList<>(proto.getActiveFeaturesList()));
+        }
+        if (proto.hasBoost()) {
+            builder.boost(proto.getBoost());
+        }
+        if (proto.hasXName()) {
+            builder.queryName(proto.getXName());
+        }
+
+        return builder;
+    }
+
+    /**
+     * Converts a protobuf {@link ObjectMap} into a plain {@code Map<String, Object>} suitable for the
+     * feature templates. The transport-grpc {@code ObjectMapProtoUtils} helper lives in the core module
+     * (not the published SPI artifact), so the conversion is reimplemented here.
+     */
+    private static Map<String, Object> fromObjectMap(ObjectMap objectMap) {
+        Map<String, Object> map = new HashMap<>();
+        for (Map.Entry<String, ObjectMap.Value> entry : objectMap.getFieldsMap().entrySet()) {
+            map.put(entry.getKey(), fromValue(entry.getValue()));
+        }
+        return map;
+    }
+
+    private static Object fromValue(ObjectMap.Value value) {
+        switch (value.getValueCase()) {
+            case NULL_VALUE:
+                return null;
+            case INT32:
+                return value.getInt32();
+            case INT64:
+                return value.getInt64();
+            case FLOAT:
+                return value.getFloat();
+            case DOUBLE:
+                return value.getDouble();
+            case STRING:
+                return value.getString();
+            case BOOL:
+                return value.getBool();
+            case LIST_VALUE:
+                List<Object> list = new ArrayList<>();
+                for (ObjectMap.Value listEntry : value.getListValue().getValueList()) {
+                    list.add(fromValue(listEntry));
+                }
+                return list;
+            case OBJECT_MAP:
+                return fromObjectMap(value.getObjectMap());
+            default:
+                throw new IllegalArgumentException("Unsupported ObjectMap value type: " + value.getValueCase());
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/org.opensearch.transport.grpc.spi.QueryBuilderProtoConverter
+++ b/src/main/resources/META-INF/services/org.opensearch.transport.grpc.spi.QueryBuilderProtoConverter
@@ -1,0 +1,1 @@
+com.o19s.es.ltr.query.StoredLtrQueryBuilderProtoConverter


### PR DESCRIPTION
### Description
Adds a `QueryBuilderProtoConverter` SPI implementation so LTR (`sltr`) queries can be executed over the gRPC transport.

The `transport-grpc` module dispatches each incoming protobuf query by its `QueryContainer` case to a registered converter, which translates the protobuf message into an OpenSearch QueryBuilder. Core registers converters only for built-in queries; plugin queries must supply their own via the `QueryBuilderProtoConverter` SPI. Without this, an `sltr` query sent over gRPC is rejected at dispatch with `Unsupported query type in container (case: SLTR)` — so this converter is required for LTR search over gRPC to work at all.

Note: This PR depends on a new `opensearch-protobufs` release that includes the `sltr` query. The converter references generated symbols (org.opensearch.protobufs.StoredLtrQuery, QueryContainer.QueryContainerCase.SLTR, getSltr()) that do not exist in the current published protobufs version (1.6.0)

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
