### PR TITLE
Don't let one CI matrix leg cancel the required checks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,9 @@ jobs:
     if: github.repository == 'opensearch-project/opensearch-learning-to-rank-base'
     runs-on: ubuntu-latest
     strategy:
+      # Let every matrix leg report independently. Branch protection requires the
+      # java 21 checks, and fail-fast would cancel them when another leg fails.
+      fail-fast: false
       matrix:
         java: [21, 25]
     steps:
@@ -35,6 +38,7 @@ jobs:
   Build-ltr-linux:
     needs: [Get-CI-Image-Tag, spotless]
     strategy:
+      fail-fast: false
       matrix:
         java: [21, 25]
 
@@ -75,6 +79,7 @@ jobs:
 
   Build-ltr-windows:
     strategy:
+      fail-fast: false
       matrix:
         java: [21 , 25]
     name: Build and Test LTR Plugin on Windows


### PR DESCRIPTION
### Description

The `spotless`, `Build-ltr-linux` and `Build-ltr-windows` jobs each declare a java matrix with no `fail-fast` key, so all three default to `fail-fast: true`. When any leg fails, GitHub cancels its siblings.

Branch protection (`repo_all_branches_exclude_app_branches`) requires exactly:

- `Build and Test LTR Plugin on Linux (21)`
- `Build and Test LTR Plugin on Windows (21)`
- `spotless (21)`

So a failure on the java 25 leg cancels the required java 21 leg, which then reports as not-passing even though it never ran. Several open PRs are currently blocked this way for reasons that have nothing to do with their contents: #401 and #399 both show CANCELLED on a required check.

Setting `fail-fast: false` makes every leg report on its own, so a red check means that configuration actually failed.

No functional change to the build.