### PR TITLE
[Backport 3.8] Don't let one CI matrix leg cancel the required checks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,9 @@ jobs:
     if: github.repository == 'opensearch-project/opensearch-learning-to-rank-base'
     runs-on: ubuntu-latest
     strategy:
+      # Let every matrix leg report independently. Branch protection requires the
+      # java 21 checks, and fail-fast would cancel them when another leg fails.
+      fail-fast: false
       matrix:
         java: [21, 25]
     steps:
@@ -35,6 +38,7 @@ jobs:
   Build-ltr-linux:
     needs: [Get-CI-Image-Tag, spotless]
     strategy:
+      fail-fast: false
       matrix:
         java: [21, 25]
 
@@ -75,6 +79,7 @@ jobs:
 
   Build-ltr-windows:
     strategy:
+      fail-fast: false
       matrix:
         java: [21 , 25]
     name: Build and Test LTR Plugin on Windows


### PR DESCRIPTION
### Description

Backport of #403 to 3.8. Same change, same matrix (`[21, 25]`).

The `spotless`, `Build-ltr-linux` and `Build-ltr-windows` jobs declare a java matrix with no `fail-fast` key, so they default to `fail-fast: true`. A failure on the java 25 leg cancels the required java 21 leg, which then reports as not-passing without having run.

Setting `fail-fast: false` lets every leg report on its own. No functional change to the build.