### PR TITLE
Make the 2.19 required checks reachable again

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,9 @@ jobs:
     if: github.repository == 'opensearch-project/opensearch-learning-to-rank-base'
     runs-on: ubuntu-latest
     strategy:
+      # Let every matrix leg report independently. Branch protection requires the
+      # java 21 checks, and fail-fast would cancel them when another leg fails.
+      fail-fast: false
       matrix:
         java: [21]
     steps:
@@ -41,6 +44,7 @@ jobs:
   Build-ltr-linux:
     needs: [Get-CI-Image-Tag, spotless]
     strategy:
+      fail-fast: false
       matrix:
         java: [ 11, 17, 21 ]
 
@@ -78,8 +82,12 @@ jobs:
 
   Build-ltr-windows:
     strategy:
+      fail-fast: false
       matrix:
-        java: [ 11, 17, 21 ]
+        # java 11 is omitted on Windows: :validatePluginZipPom loads plexus-utils,
+        # which ships class file version 61.0 (java 17) and cannot run on a java 11
+        # JVM. Linux still covers java 11, so runtime support is unaffected.
+        java: [ 17, 21 ]
     name: Build and Test LTR Plugin on Windows
     if: github.repository == 'opensearch-project/opensearch-learning-to-rank-base'
     needs: [spotless]

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/maven2/" }
+    maven { url "https://ci.opensearch.org/m2/" }
     mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     maven { url "https://plugins.gradle.org/m2/" }
@@ -116,6 +117,7 @@ publishing {
 repositories {
   mavenLocal()
   maven { url "https://ci.opensearch.org/maven2/" }
+  maven { url "https://ci.opensearch.org/m2/" }
   mavenCentral()
   maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
   maven { url "https://plugins.gradle.org/m2/" }

--- a/build.gradle
+++ b/build.gradle
@@ -144,9 +144,9 @@ configurations.all {
   resolutionStrategy.force "com.google.guava:guava:32.1.3-jre"
   resolutionStrategy.force 'org.eclipse.platform:org.eclipse.core.runtime:3.29.0'
   resolutionStrategy.force 'com.google.errorprone:error_prone_annotations:2.41.0'
-  resolutionStrategy.force 'org.apache.logging.log4j:log4j-core:2.25.4'
-  resolutionStrategy.force 'org.apache.logging.log4j:log4j-api:2.25.4'
-  resolutionStrategy.force 'org.apache.logging.log4j:log4j-jul:2.25.4'
+  resolutionStrategy.force 'org.apache.logging.log4j:log4j-core:2.25.5'
+  resolutionStrategy.force 'org.apache.logging.log4j:log4j-api:2.25.5'
+  resolutionStrategy.force 'org.apache.logging.log4j:log4j-jul:2.25.5'
 }
 
 configurations {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 pluginManagement {
     repositories {
         maven { url "https://ci.opensearch.org/maven2/" }
+        maven { url "https://ci.opensearch.org/m2/" }
         gradlePluginPortal()
         mavenCentral()
     }


### PR DESCRIPTION
### Description

The 2.19 branch is the only 2.x line still under maintenance (2.19.7 is scheduled for 2026-10-20), but its required checks currently cannot go green. Three unrelated problems combine to cause that, so this fixes all three together.

1. No `fail-fast` key on any of the three matrix jobs, so they default to `fail-fast: true`. Branch protection requires `Build and Test LTR Plugin on Linux (21)`, `Build and Test LTR Plugin on Windows (21)` and `spotless (21)`, so a failure on any other leg cancels a required one, which then reports as not-passing without ever having run. This is what is blocking #387, an already-approved security backport whose Linux 11, 17 and 21 legs all passed.

2. Windows java 11 fails in `:validatePluginZipPom` with:

   ```
   org/codehaus/plexus/util/xml/pull/XmlPullParser has been compiled by a more recent
   version of the Java Runtime (class file version 61.0), this version of the Java
   Runtime only recognizes class file versions up to 55.0
   ```

   That is a build-tooling limit rather than a runtime one, and it was taking the required Windows (21) leg down with it. Dropping 11 from the Windows matrix only; Linux still builds and tests on java 11, so runtime support is unchanged.

3. Dependency resolution intermittently takes a 503 from `ci.opensearch.org`, which is what killed spotless on #366. Adds the `ci.opensearch.org/m2` mirror to `build.gradle` and `settings.gradle`, matching #394 on main and #395 on 3.8. This branch never received it.

Since CI.yml here triggers on plain `pull_request`, the workflow change applies to this PR's own run, so it verifies its own fix.

4. log4j is pinned at 2.25.4, which Mend flags for CVE-2026-49844 (medium, 5.8). Bumped core, api and jul together to 2.25.5, the suggested fix. Those pins arrived with e2eac39 to address CVE-2026-34478, so this keeps that fix and moves it forward.

Note on the Mend report: it names main as the base branch and reports "1 new vulnerability introduced in this branch", but the base branch commit it cites, 7298e789, is on main and is not an ancestor of 2.19. log4j-api 2.25.4 was already pinned on 2.19 before this PR, so it was pre-existing on the target branch rather than introduced here. The bump fixes it either way.