### PR TITLE
[Backport 2.19] Add Eclipse P2 mirror to avoid download.eclipse.org outages (opensearch-learning-to-rank-base)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,7 +268,7 @@ spotless {
     removeUnusedImports()
     importOrder 'java', 'javax', 'org', 'com'
 
-    eclipse().configFile rootProject.file('.eclipseformat.xml')
+    eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('.eclipseformat.xml')
   }
 }
 


### PR DESCRIPTION
### Description
Onboards the Eclipse JDT formatter P2 mirror (`withP2Mirrors` -> `https://ci.opensearch.org/`) on the `2.19` branch so Spotless resolves the formatter through the OpenSearch CI CloudFront mirror instead of the throttled `download.eclipse.org` origin. Backport of the main change (#412); this repo was not part of the original mirror rollout (opensearch-build#6421).

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6421

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
