### PR TITLE
Guard eclipse() to spotless tasks and keep P2 mirror on pinned version (opensearch-learning-to-rank-base)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ plugins {
   id 'idea'
   id 'maven-publish'
   id 'jacoco'
-  id 'com.diffplug.spotless' version '6.25.0' apply false
+  id 'com.diffplug.spotless' version '8.10.1' apply false
 }
 
 group = 'org.opensearch'
@@ -276,11 +276,20 @@ thirdPartyAudit {
 
 plugins.withId('com.diffplug.spotless') {
   // Configure Spotless only if/when the plugin is applied (e.g., by parent project)
+  // Only wire the Eclipse JDT step when a spotless task is actually being run, so non-spotless
+  // Gradle invocations (test, assemble) don't provision the formatter at configuration time.
+  def runningSpotlessTask = gradle.startParameter.taskNames.any { it.toLowerCase(Locale.ROOT).contains('spotless') }
   spotless {
     java {
       removeUnusedImports()
       importOrder 'java', 'javax', 'org', 'com'
-      eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('.eclipseformat.xml')
+      // Pin 4.29 explicitly: spotless 8.10.0+ ships an embedded lockfile for it, so the
+      // formatter resolves from Maven Central through the mirror below instead of querying a
+      // P2 update site at configuration time. Keep withP2Mirrors so any non-lockfile fallback
+      // still hits the ci.opensearch.org mirror rather than the eclipse.org origin.
+      if (runningSpotlessTask) {
+        eclipse('4.29').withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('.eclipseformat.xml')
+      }
     }
   }
 }


### PR DESCRIPTION
### Description
Guard eclipse() to spotless tasks and keep P2 mirror on pinned version.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6421

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
