### PR TITLE
[Backport 2.19] Guard eclipse() to spotless tasks and keep P2 mirror on pinned version (opensearch-learning-to-rank-base)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c 'whoami && java -version && 
-                              ./gradlew -Dtests.security.manager=false clean test -x spotlessJava'
+                              ./gradlew -Dtests.security.manager=false clean test'
 
 
   Build-ltr-windows:
@@ -97,4 +97,4 @@ jobs:
       - name: Build and Run Tests
         shell: bash
         run: |
-          ./gradlew.bat build -x spotlessJava
+          ./gradlew.bat build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,7 @@ jobs:
     if: github.repository == 'opensearch-project/opensearch-learning-to-rank-base'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         java: [21]
     steps:
@@ -41,6 +42,7 @@ jobs:
   Build-ltr-linux:
     needs: [Get-CI-Image-Tag, spotless]
     strategy:
+      fail-fast: false
       matrix:
         java: [ 11, 17, 21 ]
 
@@ -78,6 +80,7 @@ jobs:
 
   Build-ltr-windows:
     strategy:
+      fail-fast: false
       matrix:
         java: [ 11, 17, 21 ]
     name: Build and Test LTR Plugin on Windows

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,12 @@ buildscript {
 
   dependencies {
     classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
+    // Spotless 8.10.x requires a Java 17+ runtime to resolve its plugin. Only put it on the
+    // buildscript classpath on Java 17+ so the Java 11 CI matrix doesn't fail resolving it.
+    // The plugin is applied (also gated to Java 17+) further below only when available.
+    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+      classpath "com.diffplug.spotless:spotless-plugin-gradle:8.10.1"
+    }
   }
 }
 
@@ -35,7 +41,6 @@ plugins {
   id 'java'
   id 'idea'
   id 'maven-publish'
-  id 'com.diffplug.spotless' version '6.23.0'
 }
 
 group = 'org.opensearch'
@@ -263,12 +268,29 @@ thirdPartyAudit {
   ignoreViolations('org.conscrypt.Platform')
 }
 
-spotless {
-  java {
-    removeUnusedImports()
-    importOrder 'java', 'javax', 'org', 'com'
+// Spotless 8.10.x (the pinned Eclipse-JDT toolchain) requires a Java 17+ runtime to even
+// resolve/apply its Gradle plugin. Skip it on older JDKs (e.g. the Java 11 CI matrix) so
+// non-spotless builds don't fail at configuration time. Formatting still runs on Java 17+.
+if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+  apply plugin: 'com.diffplug.spotless'
 
-    eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('.eclipseformat.xml')
+  // Only wire the Eclipse JDT step when a spotless task is actually being run, so non-spotless
+  // Gradle invocations don't provision the formatter at configuration time.
+  def runningSpotlessTask = gradle.startParameter.taskNames.any { it.toLowerCase(Locale.ROOT).contains('spotless') }
+
+  spotless {
+    java {
+      removeUnusedImports()
+      importOrder 'java', 'javax', 'org', 'com'
+
+      // Pin 4.27 explicitly: spotless 8.10.0+ ships an embedded lockfile for it, so the
+      // formatter resolves from Maven Central through the mirror below instead of querying a
+      // P2 update site at configuration time. 4.27 keeps the formatting identical to the
+      // eclipse() default of the previous spotless 6.23.0 this branch used.
+      if (runningSpotlessTask) {
+        eclipse('4.27').withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('.eclipseformat.xml')
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Backport 8c4fbe49a2221ec7602eea7070393cfaeffdae39 from #415.